### PR TITLE
Fix global find-replace error (k -> k.txt)

### DIFF
--- a/examples/Optical_constants_RAT_of_ITO_films.py
+++ b/examples/Optical_constants_RAT_of_ITO_films.py
@@ -29,7 +29,7 @@ for i in range(len(e_inf)):
     plt.plot(x/1000, out['A'], 'r', label='A ' + label[i], ls=ls[i])
     plt.plot(x/1000, out['T'], 'g', label='T ' + label[i], ls=ls[i])
 
-    # And also want to know the n and k.txt data
+    # And also want to know the n and k data
     n = model.n_and_k(x)
 
     plt.figure(2)

--- a/solcore/absorption_calculator/adachi_alpha.py
+++ b/solcore/absorption_calculator/adachi_alpha.py
@@ -5,13 +5,13 @@ from solcore.science_tracker import science_reference
 
 
 def create_adachi_alpha(material, Esteps=(1.42, 6, 3000), T=300, wl=None):
-    """ Calculates the n, k.txt and absorption coefficient of a material using Adachi's formalism of critical points.
+    """ Calculates the n, k and absorption coefficient of a material using Adachi's formalism of critical points.
 
     :param material: A solcore material
     :param Esteps: (1.42, 6, 3000) A tuple with the start, end and step energies in which calculating the optical data
     :param T: (300) Temeprature in kelvin
     :param wl: (None) Optional array indicating the wavelengths in which calculating the data
-    :return: A tuple containing 4 arrays: (Energy, n, k.txt, alpha)
+    :return: A tuple containing 4 arrays: (Energy, n, k, alpha)
     """
 
     science_reference("Adachi optical dispersion relations",
@@ -172,7 +172,7 @@ if __name__ == '__main__':
 
     curves = [
         GraphData(E, nn, label="n", linewidth=2, color="red"),
-        GraphData(E, kk, label="k.txt", linewidth=2, color="grey"),
+        GraphData(E, kk, label="k", linewidth=2, color="grey"),
     ]
 
     g = Graph(curves, yscale="log", legend="best", xlim=(0, 6), ylim=(1e-3, 10)).draw()

--- a/solcore/absorption_calculator/dielectric_constant_models.py
+++ b/solcore/absorption_calculator/dielectric_constant_models.py
@@ -453,6 +453,6 @@ if __name__ == '__main__':
     n = model.n_and_k(E)
     #
     plt.semilogx(E, np.real(n), 'b', label='n')
-    plt.semilogx(E, np.imag(n), 'r', label='k.txt')
+    plt.semilogx(E, np.imag(n), 'r', label='k')
     plt.legend()
     plt.show()

--- a/solcore/absorption_calculator/sopra_db.py
+++ b/solcore/absorption_calculator/sopra_db.py
@@ -159,14 +159,14 @@ class sopra_database:
         return (Wav, ((4 * np.pi) / (Wav * 1E-9)) * k)
 
     def load_temperature(self, Lambda, T=300):
-        """ SOPRA_DB.load_temperature(T, Lambda) :: Loads n and k.txt data for a set of materials with temperature dependent
+        """ SOPRA_DB.load_temperature(T, Lambda) :: Loads n and k data for a set of materials with temperature dependent
                 data sets
             Optional argument T defaults to 300K
             Required argument Lambda specifies a wavelength range and the data is interpolated to fit. This is a
                 required argument here as not all data sets in a group are the same length (will be fixed in a
                 subsequent update).
 
-            Returns: Tuple of (Wavelength, n, k.txt) """
+            Returns: Tuple of (Wavelength, n, k) """
 
         T_degC = T - 273.15  # Convert from Kelvin to degC (units given in the data)...
 
@@ -201,7 +201,7 @@ class sopra_database:
                                           skip_header=3, skip_footer=3, usecols=(2, 3, 4), unpack=True)
 
                 if Lambda is not None:
-                    # Interpolate if the Lambda argument is specified, if not pass loaded Wav, n and k.txt...
+                    # Interpolate if the Lambda argument is specified, if not pass loaded Wav, n and k...
                     n_interp = np.interp(Lambda, Wav, n)
                     k_interp = np.interp(Lambda, Wav, k)
 

--- a/solcore/absorption_calculator/transfer_matrix.py
+++ b/solcore/absorption_calculator/transfer_matrix.py
@@ -16,7 +16,7 @@ class OptiStack(object):
     """ Class that contains an optical structure: a sequence of layers with a thickness and a complex refractive index.
 
     It serves as an intermediate step between solcore layers and materials and the stack of thicknesses and
-    and n and k.txt values necessary to run calculations involving TMM. When creating an OptiStack object, the thicknesses
+    and n and k values necessary to run calculations involving TMM. When creating an OptiStack object, the thicknesses
     of all the layers forming the Solcore structure and the optical data of the materials of the layers are extracted
     and arranged in such a way they can be easily and fastly read by the TMM functions.
 
@@ -59,7 +59,7 @@ class OptiStack(object):
         supressed, usefull for ellipsometry calculations. This is done by creating an artificial highly absorbing but
         not reflecting layer just at the back.
 
-        Alternativelly, it can take simply a list of [thickness, DielectricModel] or [thickness, wavelength, n, k.txt] for
+        Alternativelly, it can take simply a list of [thickness, DielectricModel] or [thickness, wavelength, n, k] for
         each layer accounting for the refractive index of the layers. The three options can be mixed for maximum
         flexibility.
 
@@ -130,21 +130,21 @@ class OptiStack(object):
             return [np.inf] + self.widths + [np.inf]
 
     def _k_absorbing(self, wl):
-        """ k.txt value of the back highly absorbing layer. It is the maximum between the bottom layer of the stack or a
+        """ k value of the back highly absorbing layer. It is the maximum between the bottom layer of the stack or a
         finite, small value that will absorb all light within the absorbing layer thickness.
 
         :param wl: Wavelength of the light in nm.
-        :return: The k.txt value at each wavelength.
+        :return: The k value at each wavelength.
         """
         return np.maximum(wl / 1e-3, self.k_data[-1](wl))
 
     @staticmethod
     def _k_dummy(wl):
-        """ Dummy k.txt value to be used with the dielectric model, which produces the refractive index as a complex
+        """ Dummy k value to be used with the dielectric model, which produces the refractive index as a complex
         number.
 
         :param wl: Wavelength of the light in nm.
-        :return: The k.txt value at each wavelength... set to zero.
+        :return: The k value at each wavelength... set to zero.
         """
         return 0.
 
@@ -212,7 +212,7 @@ class OptiStack(object):
         self.k_data[idx1], self.k_data[idx2] = self.k_data[idx2], self.k_data[idx1]
 
     def _add_solcore_layer(self, layer):
-        """ Adds a Solcore layer to the end (bottom) of the stack, extracting its thickness and n and k.txt data.
+        """ Adds a Solcore layer to the end (bottom) of the stack, extracting its thickness and n and k data.
 
         :param layer: The Solcore layer
         :return: None

--- a/solcore/config_tools.py
+++ b/solcore/config_tools.py
@@ -128,7 +128,7 @@ def add_materials_source(name, location):
     """ Adds a Materials source to Solcore.
 
     :param name: The name of the source.
-    :param location: The full path to the location of the source. The source must be a folder containing the n and k.txt
+    :param location: The full path to the location of the source. The source must be a folder containing the n and k
     data of the material. See the the Material System in the manual for more information.
     :return: None
     """

--- a/solcore/crystals.py
+++ b/solcore/crystals.py
@@ -58,14 +58,14 @@ def traverse_brillouin(a, traverse_order=("L", "Gamma", "X", "W", "K", "Gamma"),
 
 
 def kvector(a, t=0, p=np.pi, fraction=0.2, points=50, vin=None):
-    """ Calculates the k.txt points in a direction given by the spheric angles theta (t) and phi (p).
+    """ Calculates the k points in a direction given by the spheric angles theta (t) and phi (p).
     
     The fraction of the Brilluin zone calculated is given by "fraction" and the number of points by "points".
     If "vin" is given, the direction of interest is taken from this vector."""
 
     s3 = np.sqrt(3)
 
-    # Maximum k.txt in the high symmetry directions
+    # Maximum k in the high symmetry directions
     Xkmax = 2 * np.pi / a
     Lkmax = s3 * np.pi / a
 

--- a/solcore/data_analysis_tools/ellipsometry_analysis.py
+++ b/solcore/data_analysis_tools/ellipsometry_analysis.py
@@ -139,7 +139,7 @@ class EllipsometryFitter:
     def set_variables(self, vars):
         """ Sets the variables that will be used during the fitting. The input variable "vars" is a list with as many
         elements as layers in the model. Each of these elemenets is, in turn, a list with the names of the free
-        variables of that layer. If the layers are defined by a dielectric model - rather than experimental n and k.txt data
+        variables of that layer. If the layers are defined by a dielectric model - rather than experimental n and k data
         the variable names other than the thickness and e_inf must be inside a list.
 
         vars =  [   [],

--- a/solcore/material_system/critical_point_interpolate.py
+++ b/solcore/material_system/critical_point_interpolate.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
     plt.yscale("log")
     nm = np.linspace(200, 1000, 1000)
     for k in data.keys():
-        # print (data[k.txt][0]*1e9, data[k.txt][1])
+        # print (data[k][0]*1e9, data[k][1])
         plt.plot(data[k][0] * 1e9, data[k][1], label=str(k), color="grey")
 
     resultx, resulty, crit = critical_point_interpolate(data, critical_points, 0, nm * 1e-9)

--- a/solcore/material_system/material_system.py
+++ b/solcore/material_system/material_system.py
@@ -49,9 +49,9 @@ class MaterialSystem(SourceManagedClass, metaclass=Singleton):
         >>> AlGaAs_2 = AlGaAs(Al=0.7, T=290)     # Different composition and T (the default is T=300K)
 
 
-        The material is created from the parameters in the parameter_system and the n and k.txt data if available. If the
-        n and k.txt data does not exists - at all or for that composition - then n=1 and k.txt=0 at all wavelengths. Keep in
-        mind that the available n and k.txt data is valid only at room temperature.
+        The material is created from the parameters in the parameter_system and the n and k data if available. If the
+        n and k data does not exists - at all or for that composition - then n=1 and k=0 at all wavelengths. Keep in
+        mind that the available n and k data is valid only at room temperature.
 
         :param name: Name of the material
         :param sopra: If a SOPRA material must be used, rather than the normal database material, in case both exist.

--- a/solcore/poisson_drift_diffusion/DeviceStructure.py
+++ b/solcore/poisson_drift_diffusion/DeviceStructure.py
@@ -141,7 +141,7 @@ def LoadAbsorption(layer, T, wavelengths, use_Adachi=False):
 
     if use_Adachi:
         try:
-            # 0 = Energy, 1 = n, 2 = k.txt, 3 = Absorption
+            # 0 = Energy, 1 = n, 2 = k, 3 = Absorption
             absorption = adachi_alpha.create_adachi_alpha(InLineComposition(layer), T=T, wl=wavelengths)[3]
         except:
             print("Warning: Using experimental data to estimate the absorption coefficient of material: ",
@@ -170,7 +170,7 @@ def LoadAbsorption(layer, T, wavelengths, use_Adachi=False):
         except Exception as err:
             print("Warning: Using Adachi calculation to estimate the absorption coefficient of material: ",
                   InLineComposition(layer))
-            # 0 = Energy, 1 = n, 2 = k.txt, 3 = Absorption
+            # 0 = Energy, 1 = n, 2 = k, 3 = Absorption
             try:
                 absorption = adachi_alpha.create_adachi_alpha(InLineComposition(layer), T=T, wl=wavelengths)[3]
             except:

--- a/solcore/quantum_mechanics/high_level_kp_QW.py
+++ b/solcore/quantum_mechanics/high_level_kp_QW.py
@@ -21,7 +21,7 @@ def schrodinger(structure, plot_bands=False, kpoints=40, krange=1e9, num_eigenva
 
     :param structure: The strucutre to solve
     :param plot_bands: (False) If the bands should be plotted
-    :param kpoints: (30) The number of points in the k.txt space
+    :param kpoints: (30) The number of points in the k space
     :param krange: (1e-9) The range in the k space
     :param num_eigenvalues: (10) Maximum number of eigenvalues to calculate
     :param symmetric: (True) If the structure is symmetric, in which case the calculation can be speed up

--- a/solcore/quantum_mechanics/kp_QW.py
+++ b/solcore/quantum_mechanics/kp_QW.py
@@ -262,7 +262,8 @@ def solve_holes_QW_at_kt_4x4(kt, z, fhh, flh, g1, g2, g3, num=(10, 10), quasicon
     fhh = (offset - fhh) / E0
     flh = (offset - flh) / E0
 
-    # Fill the components of the equations based on the effective masses, potential and k.txt value
+    # Fill the components of the equations based on the effective masses, potential and k value
+    # Fill the components of the equations based on the effective masses, potential and k value
     A1 = 0.5 * (g1 + g2) * kt ** 2 + fhh
     B1 = 0.5 * (g1 - g2) * kt ** 2 + flh
     A2 = 0.5 * (g1 - 2 * g2)
@@ -297,7 +298,8 @@ def solve_holes_QW_at_kt_4x4(kt, z, fhh, flh, g1, g2, g3, num=(10, 10), quasicon
 
     norm1 = [(np.sqrt(np.trapz(p * p, x=z))) for p in Psi_g1]
     norm2 = [(np.sqrt(np.trapz(p * p, x=z))) for p in Psi_g2]
-    # Normalise the wavefunction except if the norm is very small. That's the case for some E at k.txt near 0 only
+    # Normalise the wavefunction except if the norm is very small. That's the case for some E at k near 0 only
+    # Normalise the wavefunction except if the norm is very small. That's the case for some E at k near 0 only
     for i in range(len(Psi_g1)):
         if norm1[i] > 0.01 * max(norm1):
             Psi_g1[i] = Psi_g1[i] / norm1[i]
@@ -438,7 +440,8 @@ def solve_electrons_QW_at_kt_parabolic(kt, z, fe, me, num=(10, 10), quasiconfine
 
 
 def band_sorting(bands, symmetric=False):
-    """ Sort the bands in C, HH and LH according to their character at k.txt=0
+    """ Sort the bands in C, HH and LH according to their character at k=0
+    """ Sort the bands in C, HH and LH according to their character at k=0
     :param bands: A dictionary containing the bandstructure as calculated by solve_electrons_QW_at_kt_parabolic and
             solve_holes_QW_at_kt_4x4
     :return: A dictionary with the same input information but arranged in a different way, including labels
@@ -483,8 +486,8 @@ def band_sorting(bands, symmetric=False):
                 holes_U[i, j] = np.inf
 
     # Conduction bands are easy to organise... the are all the same!!
-    # For the hole bands, we say it is HH if the norm of Psi_g1 at k.txt=0 is 1, and LH otherwise
-    # This sorting is not very reliable as just outside k.txt=0 the band can be strongly (mostly) LH-like
+    # For the hole bands, we say it is HH if the norm of Psi_g1 at k=0 is 1, and LH otherwise
+    # This sorting is not very reliable as just outside k=0 the band can be strongly (mostly) LH-like
     for i in range(num_e):
         Ee.append(electrons[:, i])
         psi_e.append(Psi_e[:, i, :])
@@ -545,7 +548,7 @@ def band_sorting(bands, symmetric=False):
     psi_hh = np.array(psi_hh)
     psi_lh = np.array(psi_lh)
 
-    return {"kt": kt,           # k.txt points
+    return {"kt": kt,           # k points
             "Ee": Ee,           # Electron energy levels vs K
             "psi_e": psi_e,     # Electron wavefunctions vs X and K
             "Ehh": Ehh,         # Heavy hole energy levels vs K
@@ -575,7 +578,8 @@ def solve_bandstructure_QW(structure, num=10, kpoints=40, krange=5e9, quasiconfi
                                                quasiconfined=quasiconfined))
     bands.append([0.0, new_kpoint])
 
-    # We search only for the solutions corresponding to energy levels confined at k.txt=0
+    # We search only for the solutions corresponding to energy levels confined at k=0
+    # We search only for the solutions corresponding to energy levels confined at k=0
     num_e = len(new_kpoint['E_e'])
     num_h = len(new_kpoint['E_U'])
 

--- a/solcore/quantum_mechanics/kp_QW.py
+++ b/solcore/quantum_mechanics/kp_QW.py
@@ -263,7 +263,6 @@ def solve_holes_QW_at_kt_4x4(kt, z, fhh, flh, g1, g2, g3, num=(10, 10), quasicon
     flh = (offset - flh) / E0
 
     # Fill the components of the equations based on the effective masses, potential and k value
-    # Fill the components of the equations based on the effective masses, potential and k value
     A1 = 0.5 * (g1 + g2) * kt ** 2 + fhh
     B1 = 0.5 * (g1 - g2) * kt ** 2 + flh
     A2 = 0.5 * (g1 - 2 * g2)
@@ -298,7 +297,6 @@ def solve_holes_QW_at_kt_4x4(kt, z, fhh, flh, g1, g2, g3, num=(10, 10), quasicon
 
     norm1 = [(np.sqrt(np.trapz(p * p, x=z))) for p in Psi_g1]
     norm2 = [(np.sqrt(np.trapz(p * p, x=z))) for p in Psi_g2]
-    # Normalise the wavefunction except if the norm is very small. That's the case for some E at k near 0 only
     # Normalise the wavefunction except if the norm is very small. That's the case for some E at k near 0 only
     for i in range(len(Psi_g1)):
         if norm1[i] > 0.01 * max(norm1):
@@ -577,7 +575,6 @@ def solve_bandstructure_QW(structure, num=10, kpoints=40, krange=5e9, quasiconfi
                                                quasiconfined=quasiconfined))
     bands.append([0.0, new_kpoint])
 
-    # We search only for the solutions corresponding to energy levels confined at k=0
     # We search only for the solutions corresponding to energy levels confined at k=0
     num_e = len(new_kpoint['E_e'])
     num_h = len(new_kpoint['E_U'])

--- a/solcore/quantum_mechanics/kp_QW.py
+++ b/solcore/quantum_mechanics/kp_QW.py
@@ -441,7 +441,6 @@ def solve_electrons_QW_at_kt_parabolic(kt, z, fe, me, num=(10, 10), quasiconfine
 
 def band_sorting(bands, symmetric=False):
     """ Sort the bands in C, HH and LH according to their character at k=0
-    """ Sort the bands in C, HH and LH according to their character at k=0
     :param bands: A dictionary containing the bandstructure as calculated by solve_electrons_QW_at_kt_parabolic and
             solve_holes_QW_at_kt_4x4
     :return: A dictionary with the same input information but arranged in a different way, including labels

--- a/solcore/quantum_mechanics/kp_bulk.py
+++ b/solcore/quantum_mechanics/kp_bulk.py
@@ -22,7 +22,7 @@ def eight_band_strain_hamiltonian(kx, ky, kz, Ev0, Ec0, exx, ezz, me_eff, gamma1
     See Hamiltonian in ref. but remove row 1 and 6 and column 1 and 6.
     http://prb.aps.org/pdf/PRB/v73/i12/e125348"""
     science_reference("k.p Hamiltonian", "Stanko Tomic et al., Electronic structure of InyGa1yAs1xNxGaAs(N) quantum "
-                                         "dots by ten-band k.txt.p theory. Phys. Rev. B 73, 125348 (2006)")
+                                         "dots by ten-band k.p theory. Phys. Rev. B 73, 125348 (2006)")
 
     av = abs(
         av)  # The sign in Vurgaftmann is negative while Chuang (and Tomic) assumes it is possitve. We make sure it truly is.
@@ -258,7 +258,7 @@ def KPbands(material, host_material, return_edges_only=False, plot_result=False,
     """ New version of the above function that produces either the band edges or the full bands in one specifc direction
     from Gamma.
     
-    - Calculation of the full Brillouin zone is not allowed. After all, KP is only valid near k.txt=0
+    - Calculation of the full Brillouin zone is not allowed. After all, KP is only valid near k=0
     - The calculation of the effective masses is done externally by another function
     - The direction to calculate the bands is provided either with directory angles or a directory vector
     - The number of points of the bands and the fraction up to the border of the Brilluin zone in the given direction are also inputs
@@ -326,7 +326,7 @@ def fit_effective_masses(bands, material, host_material, plot_result=False, dk=0
     masses = []
     a0 = material.lattice_constant
 
-    # General maximum k.txt value. The actual maximum value depends on the direction,
+    # General maximum k value. The actual maximum value depends on the direction,
     # but the difference is generally not too big
     kmax = 2 * np.pi / a0
 
@@ -376,7 +376,7 @@ def average_inplane_effective_mass(material, host_material, averaging_points=10,
     """ Calculates the average in-plane effective mass for the four bands, assuming always the XY plane. """
 
     # p = phi = Polar angle, always constant for the XY plane
-    # t = theta = Azimuth. Given the symmetry of the problem, we need to average only 45˚ of the k.txt space
+    # t = theta = Azimuth. Given the symmetry of the problem, we need to average only 45˚ of the k space
     p = np.pi / 2
     t = np.linspace(0, np.pi / 4, averaging_points)
 

--- a/solcore/quantum_mechanics/structure_utilities.py
+++ b/solcore/quantum_mechanics/structure_utilities.py
@@ -172,9 +172,9 @@ def structure_to_potentials(structure, step_size=None, minimum_step_size=0, smal
         substrate = structure.substrate
 
         # Now we modify the band profile and effective masses according to the chosen mode:
-        # - kp4x4, calculates the bands and effective masses at k.txt=0 coupling the HH and LH bands
-        # - kp6x6, calculates the bands and effective masses at k.txt=0 coupling the HH, LH and SO bands
-        # - kp8x8_bulk, calculates the four bands and fit the effective masses with a parabola around k.txt=0
+        # - kp4x4, calculates the bands and effective masses at k=0 coupling the HH and LH bands
+        # - kp6x6, calculates the bands and effective masses at k=0 coupling the HH, LH and SO bands
+        # - kp8x8_bulk, calculates the four bands and fit the effective masses with a parabola around k=0
         # - strain, just shifts the bands according to the strain
         # - relaxed, do nothing and things are calculated as if we had the bulk, unstrained materials
         if mode == 'kp6x6':
@@ -191,7 +191,7 @@ def structure_to_potentials(structure, step_size=None, minimum_step_size=0, smal
             Vso[positions] = so
 
         elif mode == 'kp4x4':
-            # The band edges are shifted but the effective masses around k.txt=0 are not affected.
+            # The band edges are shifted but the effective masses around k=0 are not affected.
             c, hh, lh, mc_kp, mhh_p_kp, mlh_p_kp, mhh_t_kp, mlh_t_kp = kp4x4(layer.material, substrate)
 
             Ve[positions] = c

--- a/solcore/units_system/units_system.py
+++ b/solcore/units_system/units_system.py
@@ -20,7 +20,7 @@ class WrongDimensionError(Exception):
 
 
 def generateConversionDictForSISuffix(suffix, centi=False, deci=False, non_base_si_factor=1):
-    prefixes = "Y,Z,E,P,T,G,M,k.txt,,m,u,n,p,f,a,z,y".split(",")
+    prefixes = "Y,Z,E,P,T,G,M,k,,m,u,n,p,f,a,z,y".split(",")
     exponents = list(range(8, -9, -1))
 
     if centi:
@@ -52,6 +52,7 @@ class UnitsSystem(SourceManagedClass):
             self.add_source(name, os.path.abspath(path.replace('SOLCORE_ROOT', solcore.SOLCORE_ROOT)))
 
         self.read()
+        print (self.dimensions)
 
     def read(self, name=None):
         """ Reads the units file and creates a database with all units and conversion factors. """
@@ -119,6 +120,7 @@ class UnitsSystem(SourceManagedClass):
         if unit is None or value is None:
             return value
 
+        print (unit)
         units_list = self.split_units_RE.findall(unit)
         for unit, power in units_list:
             power = float(power) if power != '' else 1
@@ -329,6 +331,7 @@ class UnitsSystem(SourceManagedClass):
             negative = "-"
         formatting = "%s%%.%if %%s" % (negative, precision)
         d = self.dimensions[dimension]
+
         possibleUnits = d.keys()
         if value == 0:
             return formatting % (0, "")

--- a/solcore/units_system/units_system.py
+++ b/solcore/units_system/units_system.py
@@ -120,7 +120,6 @@ class UnitsSystem(SourceManagedClass):
         if unit is None or value is None:
             return value
 
-        print (unit)
         units_list = self.split_units_RE.findall(unit)
         for unit, power in units_list:
             power = float(power) if power != '' else 1

--- a/solcore/units_system/units_system.py
+++ b/solcore/units_system/units_system.py
@@ -52,7 +52,6 @@ class UnitsSystem(SourceManagedClass):
             self.add_source(name, os.path.abspath(path.replace('SOLCORE_ROOT', solcore.SOLCORE_ROOT)))
 
         self.read()
-        print (self.dimensions)
 
     def read(self, name=None):
         """ Reads the units file and creates a database with all units and conversion factors. """

--- a/solcore/units_system/units_system.py
+++ b/solcore/units_system/units_system.py
@@ -329,7 +329,6 @@ class UnitsSystem(SourceManagedClass):
             negative = "-"
         formatting = "%s%%.%if %%s" % (negative, precision)
         d = self.dimensions[dimension]
-
         possibleUnits = d.keys()
         if value == 0:
             return formatting % (0, "")


### PR DESCRIPTION
At some point, an erroneous global find-and-replace function seems to have replaced every instance of "k" with "k.txt" in the solcore source. This made its way into the repository with commit 33255afe07d96910545d8311214d52f4ee916144. Most code looks like it's already corrected, but there were some issues in strings and comments, including some functional strings used by the units system.