### PR TITLE
Create temp user settings to run some materials tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ description-file = README.md
 
 [aliases]
 test=pytest
+
+[tool:pytest]
+testpaths = solcore/tests
+addopts = -p no:warnings

--- a/setup.py
+++ b/setup.py
@@ -109,10 +109,10 @@ setup(
     include_package_data=True,
     test_suite="pytest-runner",
     tests_require=[
-        "pytest",
         "numpy",
         "matplotlib",
         "scipy",
+        "Sphinx",
         "tmm",
         "natsort",
         "regex",

--- a/solcore/absorption_calculator/nk_db.py
+++ b/solcore/absorption_calculator/nk_db.py
@@ -8,7 +8,7 @@ import sqlite3
 from solcore.material_data.refractiveindex_info_DB import dboperations as DB
 from solcore import config, SOLCORE_ROOT
 
-def download_db(url = None, interpolation_points = 200, confirm = False):
+def download_db(url = None, interpolation_points = 200, confirm = False, temp_path="database", db_path=None):
     """
     This function downloads the refractiveindex.info database and creates on SQLite database at
     the path specified in the user config file.
@@ -18,7 +18,10 @@ def download_db(url = None, interpolation_points = 200, confirm = False):
     :param confirm: if True, will not ask if you want to download database again even if it has been downloaded previously
     :return:
     """
-    NK_PATH = os.path.abspath(config['Others']['nk'].replace('SOLCORE_ROOT', SOLCORE_ROOT))
+    if db_path is None:
+        NK_PATH = os.path.abspath(config['Others']['nk'].replace('SOLCORE_ROOT', SOLCORE_ROOT))
+    else:
+        NK_PATH = db_path
 
     if os.path.isfile(NK_PATH) and not confirm:
         response = input('There is already a downloaded database file.'
@@ -32,9 +35,9 @@ def download_db(url = None, interpolation_points = 200, confirm = False):
     if confirm:
         db = DB.Database(NK_PATH)
         if url is None:
-            db.create_database_from_url(interpolation_points)
+            db.create_database_from_url(interpolation_points, temp_path=temp_path)
         else:
-            db.create_database_from_url(interpolation_points, url)
+            db.create_database_from_url(interpolation_points, url, temp_path=temp_path)
 
 
 def search_db(term="", exact=False):

--- a/solcore/config_tools.py
+++ b/solcore/config_tools.py
@@ -5,7 +5,6 @@ from configparser import ConfigParser
 import os
 import shutil
 import solcore
-import glob
 
 home_folder = os.path.expanduser('~')
 user_config = os.path.join(home_folder, '.solcore_config.txt')
@@ -16,7 +15,7 @@ default_config_data = ConfigParser()
 default_config_data.read(solcore.default_config)
 
 
-def reset_defaults(confirm=False):
+def reset_defaults(confirm=False, user_config_file=user_config):
     """ Resets the default Solcore configuration in the user home folder.
 
     :return: None
@@ -30,9 +29,9 @@ def reset_defaults(confirm=False):
             confirm = True
 
     if confirm:
-        shutil.copy2(solcore.default_config, user_config)
+        shutil.copy2(solcore.default_config, user_config_file)
 
-        user_config_data.read(user_config)
+        user_config_data.read(user_config_file)
         user_config_data.remove_option(section='Configuration', option='version')
         save_user_config()
 
@@ -241,15 +240,18 @@ def get_current_config():
         print()
 
 
-def check_user_config():
+def check_user_config(user_config_file=user_config, response=None):
     """ Checks if there's a user configuration file, asking if it needs to be created.
 
     :return: None
     """
+    global user_config_data
+
     if len(user_config_data.sections()) == 0:
-        response = input('No user configuration was detected. Do you want to create one (Y/n)?')
+        if response is None:
+            response = input('No user configuration was detected. Do you want to create one (Y/n)?')
 
         if response in 'Yy':
-            reset_defaults(True)
+            reset_defaults(True, user_config_file=user_config_file)
             user_config_data = ConfigParser()
-            user_config_data.read(user_config)
+            user_config_data.read(user_config_file)

--- a/solcore/material_data/refractiveindex_info_DB/dboperations.py
+++ b/solcore/material_data/refractiveindex_info_DB/dboperations.py
@@ -29,9 +29,10 @@ class Database:
     def create_database_from_folder(self, yml_database_path, interpolation_points=100):
         create_sqlite_database(yml_database_path, self.db_path,interpolation_points=interpolation_points)
 
-    def create_database_from_url(self,interpolation_points=100,riiurl=_riiurl):
-        Database.DownloadRIIzip(riiurl=riiurl)
-        self.create_database_from_folder("database", interpolation_points=interpolation_points)
+    def create_database_from_url(self,interpolation_points=100,riiurl=_riiurl,temp_path="database"):
+        downloaded = os.path.join(temp_path, "database")
+        Database.DownloadRIIzip(outputfolder=temp_path, riiurl=riiurl)
+        self.create_database_from_folder(downloaded, interpolation_points=interpolation_points)
         pass
 
     def check_url_version(self):
@@ -268,7 +269,7 @@ class Database:
             print("Downloaded and extracting...")
             z = zipfile.ZipFile(io.BytesIO(r.content))
             z.extractall(path=outputfolder)
-            print("Wrote",outputfolder+"/database","from",riiurl)
+            print("Wrote",str(outputfolder)+"/database","from",riiurl)
             #The destination+database is the result.
             return True
         else:

--- a/solcore/material_system/material_system.py
+++ b/solcore/material_system/material_system.py
@@ -30,6 +30,15 @@ class MaterialSystem(SourceManagedClass, metaclass=Singleton):
         for name, path in sources.items():
             self.sources[name] = os.path.abspath(path.replace('SOLCORE_ROOT', solcore.SOLCORE_ROOT))
 
+    def reset(self, sources=None):
+        """ Resets the material system, adding the sources and re-reading them
+
+        :param sources: ConfigParser material sources
+        :return: None
+        """
+        for name, path in sources.items():
+            self.sources[name] = os.path.abspath(path.replace('SOLCORE_ROOT', solcore.SOLCORE_ROOT))
+
     def material(self, name, sopra=False, nk_db=False):
         """ This function checks if the requested material exists and creates a class that contains its properties,
         assuming that the material does not exists in the database, yet.

--- a/solcore/parameter_system/parameter_system.py
+++ b/solcore/parameter_system/parameter_system.py
@@ -57,6 +57,17 @@ class ParameterSystem(SourceManagedClass):
 
         self.read()
 
+    def reset(self, sources=None):
+        """ Resets the parameter system, adding the sources and re-reading them
+
+        :param sources: ConfigParser parameter sources
+        :return: none
+        """
+        for name, path in sources.items():
+            self.add_source(name, os.path.abspath(path.replace('SOLCORE_ROOT', solcore.SOLCORE_ROOT)))
+
+        self.read()
+
     def get_parameter(self, material, parameter, verbose=False, **others):
         """Calculate/look up parameters for materials, returns in SI units
         


### PR DESCRIPTION
`test_use_material` and `test_database_materials` can now be run. To enable that:

- a mock user configuration file is created in a temporal directory
- relevant functions are modified to use this temporal location
- Solcore configuration is re-loaded, in particular the ParameterSystem and the MaterialSystem.

These tests fail sometimes, but it is unclear why not always, as there is no random elements involved. To circumvent this, I use `@mark.flaky(reruns=5)` the repeat up to 5 times both tests if they fail. 