### PR TITLE
Configured pre-commit with nbstripout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/kynan/nbstripout
+  rev: master
+  hooks:
+    - id: nbstripout
+      files: ".ipynb"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ natsort
 regex
 cycler
 pyyaml
+pre-commit


### PR DESCRIPTION
Issue: #46 

Added the pre-commit in the requirements and created the pre-commit config for running nbstripout.
In order to configure pre-commit on the machine the command: `pre-commit install` it is needed. I think should be added to the setup in case of a developer, but I didn't want to mess up with the setup file.

[x] Configured pre-commit for nbstripout
[ ] Add `pre-commit install` in the setup in case of a developer
