### PR TITLE
Added Jupyter Notebook for Materials_Eg_vs_lattice_constant.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ dmypy.json
 
 # JetBrains IDE files
 .idea/
+
+# VS Code
+.vscode/

--- a/examples/notebooks/Materials_eg_vs_lattice_constant.ipynb
+++ b/examples/notebooks/Materials_eg_vs_lattice_constant.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Materials Eg vs Lattice Constant"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Import Python modules**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from solcore import material\n",
+    "from solcore import si, asUnit\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**This is the list of materials available in Solcore... yes, it could be obtained in a more automated way.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mat = ['AlInAs','AlGaAs','InGaAs', 'GaAsP','GaInP','AlGaP','AlPSb','InAsP','AlAsP','AlInP','AlGaSb','GaAsSb','GaInSb','AlInSb','InAsSb','InPSb']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**The element that varies the composition**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xx = ['Al','Al','In','P','In','Ga','Sb','As','As','Al','Al','Sb','In','In','Sb','Sb']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**And the labels for the binary compounds**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mat2 = ['GaAs', 'AlAs', 'InAs', 'InSb', 'GaSb', 'AlSb', 'GaP', 'InP', 'AlP', 'Si', 'Ge']\n",
+    "pos = [(5.58, 1.3), (5.65, 2.32), (6, 0.21), (6.44, 0.02), (6.11, 0.788), (6.15, 1.69), (5.39, 2.14), (5.89, 1.41), (5.40, 2.49), (5.44, 1.21), (5.67, 0.73)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zz = np.linspace(0, 1, 100)\n",
+    "lat = np.zeros_like(zz)\n",
+    "eg = np.zeros_like(zz)\n",
+    "\n",
+    "colors = plt.cm.jet(np.linspace(0,1,len(mat)))\n",
+    "\n",
+    "fig = plt.figure(figsize=(6,4.5))\n",
+    "ax = fig.add_subplot(111)\n",
+    "\n",
+    "for j, (m, x) in enumerate(zip(mat, xx)):\n",
+    "    for i, z in enumerate(zz):\n",
+    "        param = {x : z}\n",
+    "        new_mat = material(m)(T=300, **param)\n",
+    "\n",
+    "        lat[i] = new_mat.lattice_constant*1e10\n",
+    "        eg[i] = asUnit(new_mat.band_gap, 'eV')\n",
+    "\n",
+    "    ax.plot(lat, eg, label=m, color=colors[j])\n",
+    "\n",
+    "lat2 = []\n",
+    "eg2 = []\n",
+    "for (m, p) in zip(mat2, pos):\n",
+    "    new_mat = material(m)(T=300)\n",
+    "\n",
+    "    lat2.append(new_mat.lattice_constant*1e10)\n",
+    "    eg2.append(asUnit(new_mat.band_gap, 'eV'))\n",
+    "\n",
+    "    ax.annotate(m, xy=p)\n",
+    "\n",
+    "plt.plot(lat2, eg2, 'ko')\n",
+    "\n",
+    "plt.ylim(-0.1, 2.8)\n",
+    "\n",
+    "plt.ylabel('Band gap (eV)')\n",
+    "plt.xlabel('Lattice constant ($\\AA$)')\n",
+    "plt.legend(ncol=3, loc=\"upper right\", frameon=False, columnspacing=0.2)\n",
+    "plt.tight_layout()\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
In response to issue #46 I've converted Materials_Eg_vs_lattice_constant.py to Jupyter Notebook format.

Also added to .gitignore to exclude VS Codes config folder from being included
