### PR TITLE
Use caching to address bottleneck when using Solcore materials in an OptiStack

### DIFF
--- a/solcore/absorption_calculator/transfer_matrix.py
+++ b/solcore/absorption_calculator/transfer_matrix.py
@@ -13,6 +13,14 @@ degree = np.pi / 180
 
 
 def np_cache(function):
+    """This function was taken from https://stackoverflow.com/questions/52331944/cache-decorator-for-numpy-arrays/52332109#52332109
+    
+    Creates a cacheable version of a function which takes a 1D numpy array as input, by using a wrapping function
+    which converts the array to a tuple. It returns a function which returns the same output as the input function,
+    but can be cached, avoiding a bottleneck when optical constants in a material are looked up repeatedly.
+
+    :param: function: the function of which a cacheable version is to be created
+    :return: wrapper: the cacheable version of the function"""
     @lru_cache()
     def cached_wrapper(hashable_array):
         array = np.array(hashable_array)

--- a/solcore/absorption_calculator/transfer_matrix.py
+++ b/solcore/absorption_calculator/transfer_matrix.py
@@ -238,9 +238,12 @@ class OptiStack(object):
         :param: widths: a list or array of widths, length equal to the number of layers
         :return: None"""
 
-        #assert len(widths) == self.num_layers, \
-        #    'Error: The list of widths must have as many elements (now {}) as the ' \
-        #    'number of layers (now {}).'.format(len(widths), self.num_layers)
+        if type(widths) is np.ndarray:
+            widths = widths.tolist()
+
+        assert len(widths) == self.num_layers, \
+            'Error: The list of widths must have as many elements (now {}) as the ' \
+        'number of layers (now {}).'.format(len(widths), self.num_layers)
 
         self.widths = widths
 

--- a/solcore/absorption_calculator/transfer_matrix.py
+++ b/solcore/absorption_calculator/transfer_matrix.py
@@ -4,11 +4,9 @@ transfer matrix package developed by Steven Byrnes and included in the PyPi repo
 """
 import numpy as np
 import solcore
-import tmm as old_tmm
 from solcore.interpolate import interp1d
 from solcore.structure import ToStructure
 from solcore.absorption_calculator import tmm_core_vec as tmm
-from time import time
 from functools import lru_cache, wraps
 
 degree = np.pi / 180
@@ -125,7 +123,6 @@ class OptiStack(object):
             n0 = 1
 
         for i in range(self.num_layers):
-            start=time()
             out.append(self.n_data[i](wl_m) + self.k_data[i](wl_m) * 1.0j)
 
 


### PR DESCRIPTION
This addresses issue #45. It is not possible (as far as I can figure out) to directly wrap the relevant functions in the material_system module (n_interpolated and k_interpolated) with @lru_cache, because they take numpy arrays as inputs which are not hashable. As a workaround I have defined a new function in transfer_matrix called np_cache. This takes a function with an input 1D array, and wraps it so that the numpy array is internally converted to a tuple and back again and can be cached. I've used this new function so that each entry added to self.nk_data can now be cached. I've done some checks and this causes a significant speedup (about 4x for the problem I was looking at) when using an OptiStack which uses Solcore database materials.

I've also added a function to change the layer widths after an OptiStack has been defined (useful for optimization problems where you don't want to redefine the whole stack, just play around with the layer thicknesses).

Note that I copied the np_cache function from the answer to this StackExchange issue https://stackoverflow.com/questions/52331944/cache-decorator-for-numpy-arrays/52332109