### PR TITLE
Change how SolcoreMaterialstoStr checks if something is an alloy

### DIFF
--- a/solcore/structure.py
+++ b/solcore/structure.py
@@ -143,8 +143,6 @@ def SolcoreMaterialToStr(material_input):
 
     alloy = True if len(material_input.composition) > 0 else False
 
-    print(material_name, alloy)
-
     if alloy:
         material_composition = material_string[2].split("=")
         for i, comp in enumerate(material_composition):

--- a/solcore/structure.py
+++ b/solcore/structure.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from solcore import ParameterSystem
 import solcore
 
 
@@ -139,7 +140,12 @@ def SolcoreMaterialToStr(material_input):
     material_string = material_input.__str__().strip('<>').split(" ")
     material_name = material_string[0].strip("'")
     composition = {'material': material_name}
-    if len(material_name) > 4:
+
+    alloy = True if len(material_input.composition) > 0 else False
+
+    print(material_name, alloy)
+
+    if alloy:
         material_composition = material_string[2].split("=")
         for i, comp in enumerate(material_composition):
             if comp in material_name:


### PR DESCRIPTION
Rather than checking length of string, checks if material has a composition defined. Doing it this way rather than by checking the database because that doesn't work for SOPRA/refractiveindex.info materials. Obviously there are other problems with using those materials in the electrical solvers because they don't have the relevant parameters pre-defined, but no reason to create an issue with them here.