### PR TITLE
Stop PDD solver if not convergence. Close #51 .

### DIFF
--- a/solcore/poisson_drift_diffusion/DDmodel-current.f95
+++ b/solcore/poisson_drift_diffusion/DDmodel-current.f95
@@ -1861,7 +1861,8 @@ IF(OutputLevel>=2)WRITE(ou,'(1I10,6g14.4,1I10)') niter, Jtot, sum, sum1, sum2, s
         CHARACTER(50) :: OutputCode
         
         IF (info==1) THEN
-            OutputCode = 'Reached Maximum number of iterations.'
+            OutputCode = 'Not converging: Reached Maximum iterations.'
+            ERROR STOP OutputCode
         ELSE IF (info==2) THEN
             OutputCode = 'Reached Absolute Tolerance.'
         ELSE IF (info==3) THEN


### PR DESCRIPTION
Close #51. 

Stops the execution of the script if the maximum number of iterations are reached in the PDD solver. This avoids the problem of a user not realising of the information in the terminal that warns about this.

Reaching the maximum number of iterations nearly always means that the solver is not converging. Things might go wrong if the relative tolerance is reached, but that is sometimes acceptable, so the solver is not stoped in this case. . 