### PR TITLE
update LightSource class constructor to fix concentration bug

### DIFF
--- a/solcore/light_source/light_source.py
+++ b/solcore/light_source/light_source.py
@@ -67,7 +67,7 @@ class LightSource:
         "custom",
     ]
 
-    def __init__(self, source_type, x=None, **kwargs):
+    def __init__(self, source_type, x=None, concentration=1, **kwargs):
         """
 
         :param source_type:
@@ -84,7 +84,7 @@ class LightSource:
 
         self.options = {}
         self.output_units = "power_density_per_nm"
-        self.concentration = 1
+        self.concentration = concentration
         self.options.update(kwargs)
         self._spectrum = None
 

--- a/solcore/light_source/light_source.py
+++ b/solcore/light_source/light_source.py
@@ -74,8 +74,12 @@ class LightSource:
         :param kwargs:
         """
         msg = f"Unknown source {source_type}. " \
-              f"Valid options are: {tuple(REGISTERED_CONVERTERS.keys())}"
+              f"Valid options are: {self.type_of_source}"
         assert source_type in self.type_of_source, msg
+
+        msg = f"Unknown output units {output_units}. " \
+              f"Valid options are: {tuple(REGISTERED_CONVERTERS.keys())}"
+        assert output_units in REGISTERED_CONVERTERS, msg
 
         self.source_type = source_type
         self.x = x


### PR DESCRIPTION
Simply adding concentration as an argument to the class constructor so it's taken into account again. Addresses #121. Not sure if this is the approach you wanted to take though!