### PR TITLE
Fixes Bug GH146, where wl from instance init is ignored

### DIFF
--- a/solcore/light_source/light_source.py
+++ b/solcore/light_source/light_source.py
@@ -83,7 +83,7 @@ class LightSource:
 
         self.source_type = source_type
         self.x = x
-        self.x_internal = x
+        self.x_internal = None
         self.power_density = 0
 
         self.options = {}
@@ -115,7 +115,9 @@ class LightSource:
         source.
         :return: Array with the spectrum in the requested units
         """
-        self.x = x if x is not None else self.x_internal
+        
+        if x is None:
+            x = self.x if self.x is not None else self.x_internal
 
         output_units = output_units if output_units is not None else self.output_units
         con = concentration if concentration is not None else self.concentration
@@ -124,7 +126,7 @@ class LightSource:
         if kwargs:
             self._update(**kwargs)
             self._update_spectrum_function()
-        return self.x, self._get_spectrum(self._spectrum, self.x) * con
+        return self.x, self._get_spectrum(self._spectrum, x) * con
 
     def _update(self, **kwargs):
         """ Updates the options of the light source with new values.

--- a/solcore/light_source/light_source.py
+++ b/solcore/light_source/light_source.py
@@ -115,7 +115,7 @@ class LightSource:
         source.
         :return: Array with the spectrum in the requested units
         """
-        
+
         if x is None:
             x = self.x if self.x is not None else self.x_internal
 

--- a/tests/test_light_source.py
+++ b/tests/test_light_source.py
@@ -129,31 +129,11 @@ def test_wavelength_array_consistency():
     #GH 147
     from solcore.light_source import LightSource
     import numpy as np
-    
+
     wl_arr = np.linspace(300, 1200, 10)*1e-9
     wl_arr2 = np.linspace(300, 1200, 20)*1e-9
-    
+
     ls = LightSource(source_type='standard', version='AM1.5g', x=wl_arr,
                              output_units='photon_flux_per_m')
     assert ls.spectrum()[1].shape == wl_arr.shape
     assert ls.spectrum(x=wl_arr2)[1].shape == wl_arr2.shape
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    

--- a/tests/test_light_source.py
+++ b/tests/test_light_source.py
@@ -124,3 +124,36 @@ def test_photon_flux_per_hz(wavelength, gauss_spectrum):
 
     actual = photon_flux_per_hz(sp_fun, hz)
     assert actual * h * hz == approx(expected)
+
+def test_wavelength_array_consistency():
+    #GH 147
+    from solcore.light_source import LightSource
+    import numpy as np
+    
+    wl_arr = np.linspace(300, 1200, 10)*1e-9
+    wl_arr2 = np.linspace(300, 1200, 20)*1e-9
+    
+    ls = LightSource(source_type='standard', version='AM1.5g', x=wl_arr,
+                             output_units='photon_flux_per_m')
+    assert ls.spectrum()[1].shape == wl_arr.shape
+    assert ls.spectrum(x=wl_arr2)[1].shape == wl_arr2.shape
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    


### PR DESCRIPTION
Thanks for considering my PR.

THe PR fixes Bug #146, where the wavelength array, which is specified in class initiation, is ignored in the later function call to .spectrum()
.spectrum looks for the appropriate wl array in three places now:
-first, if specified in the function call directly
-second, if wl array was specified during class instance init (set to self.x)
-third, if no wl array was specified at all, the default wl array for the chosen source type (self.x_interal) is used.

self.x_internal is initiated to None, because it is overwritten in any source type.

Would you like me to add a unit test?