### PR TITLE
Add support for building manylinux2014 binary wheels and upload to PyPi

### DIFF
--- a/.github/workflows/build_deploy_wheels.yml
+++ b/.github/workflows/build_deploy_wheels.yml
@@ -1,0 +1,43 @@
+name: Upload Python Package
+
+on:
+  push:
+
+  release:
+    types: [published]
+
+jobs:
+  deploy_wheels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Deploy wheels - Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Deploy wheels - Install dependencies
+        run: |
+          python -m pip install --upgrade setuptools wheel pip twine numpy
+
+      - name: Deploy wheels - Build manylinux2014 binary wheels - py37/py38 - x86_64
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2014_x86_64
+        with:
+          python-versions: 'cp37-cp37m cp38-cp38'
+          build-requirements: 'numpy'
+          system-packages: 'gcc-gfortran'
+          pre-build-command: 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/; export SOLCORE_WITH_PDD=1'
+
+      - name: Deploy wheels - Build manylinux2014 binary wheels - py37/py38 - i686
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2014_i686
+        with:
+          python-versions: 'cp37-cp37m cp38-cp38'
+          build-requirements: 'numpy'
+          system-packages: 'gcc-gfortran'
+          pre-build-command: 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/; export SOLCORE_WITH_PDD=1'
+
+      - name: Deploy wheels - Upload manylinux wheels to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/build_deploy_wheels.yml
+++ b/.github/workflows/build_deploy_wheels.yml
@@ -1,8 +1,6 @@
 name: Upload Python Package
 
 on:
-  push:
-
   release:
     types: [published]
 

--- a/.github/workflows/build_deploy_wheels.yml
+++ b/.github/workflows/build_deploy_wheels.yml
@@ -34,8 +34,9 @@ jobs:
           system-packages: 'gcc-gfortran'
           pre-build-command: 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/; export SOLCORE_WITH_PDD=1'
 
-      - name: Deploy wheels - Upload manylinux wheels to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+      - name: Publish wheels to PyPI
+        env:
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          twine upload dist/*-manylinux*.whl

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ config = ConfigParser()
 config.read([default_config])
 
 # We give the option of compiling - and installing - the extension modules
-if "--with_pdd" in sys.argv:
+if (("--with_pdd" in sys.argv) or 
+    (('SOLCORE_WITH_PDD' in os.environ) and (os.environ['SOLCORE_WITH_PDD'] == "1"))):
     sources = os.path.join("solcore", "poisson_drift_diffusion", "DDmodel-current.f95")
     ext = [
         Extension(
@@ -35,7 +36,8 @@ if "--with_pdd" in sys.argv:
             f2py_options=["--quiet"],
         )
     ]
-    sys.argv.remove("--with_pdd")
+    if "--with_pdd" in sys.argv:
+        sys.argv.remove("--with_pdd")
 else:
     ext = []
 

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,11 @@ config = ConfigParser()
 config.read([default_config])
 
 # We give the option of compiling - and installing - the extension modules
-if (("--with_pdd" in sys.argv) or 
-    (('SOLCORE_WITH_PDD' in os.environ) and (os.environ['SOLCORE_WITH_PDD'] == "1"))):
-    sources = os.path.join("solcore", "poisson_drift_diffusion", "DDmodel-current.f95")
+if (("--with_pdd" in sys.argv) or
+        (('SOLCORE_WITH_PDD' in os.environ) and
+         (os.environ['SOLCORE_WITH_PDD'] == "1"))):
+    sources = os.path.join("solcore", "poisson_drift_diffusion",
+                           "DDmodel-current.f95")
     ext = [
         Extension(
             name="solcore.poisson_drift_diffusion.ddModel",


### PR DESCRIPTION
This PR partially addresses #139 by providing an additional Actions workflow for building linux binary wheels for Solcore that include the native PDD library. The workflow builds `i686` and `x86_64` solcore wheels for both Python 3.7 and 3.8.

Providing binary wheels based on the [manylinux2014](https://github.com/pypa/manylinux) spec should ensure that these wheels are deployable on a wide range of current Linux systems.

The new workflow makes use of the [Python wheels manylinux build](https://github.com/RalfG/python-wheels-manylinux-build) GitHub Action to build the wheels for the different supported architectures and Python versions.

**Enabling PDD:** Running a standard build/package for solcore using `setup.py` it's possible to use the `--with_pdd` switch to enable the building of the native PDD library. Passing the PDD switch when building via actions presented some issues which resulted in all the depdent libraries being built from source rather than simply downloading built packages from PyPi where these are available. To resolve this, `setup.py` has been modified to accept either the `--with_pdd` switch as before, or an environment variable `SOLCORE_WITH_PDD` which must be set to `1` to enable PDD support. This environment variable is then set in the Actions configuration to trigger the building of the PDD extension when the solcore package is built.

**Known issues:** Uploading packages to PyPi - the new workflow has been tested locally using [`act`](https://github.com/nektos/act) however it's not been possible to test the uploading of the generated wheels to PyPi using this approach so fixes may need to be added to this PR in the event that any issues arise with uploading the generated wheels.