### PR TITLE
Fix recursion in BaseMaterial.__getattr__ for real

### DIFF
--- a/solcore/material_system/material_system.py
+++ b/solcore/material_system/material_system.py
@@ -301,12 +301,12 @@ class BaseMaterial:
     def __getattr__(self, attrname):  # only used for unknown attributes.
         if attrname == "n":
             try:
-                return self.__getattribute__(self,attrname)
+                return self.__getattribute__(attrname)
             except AttributeError:
                 return self.n_interpolated
         if attrname == "k":
             try:
-                return self.__getattribute__(self,attrname)
+                return self.__getattribute__(attrname)
             except AttributeError:
                 return self.k_interpolated
         if attrname == "electron_affinity":

--- a/solcore/material_system/material_system.py
+++ b/solcore/material_system/material_system.py
@@ -301,13 +301,13 @@ class BaseMaterial:
     def __getattr__(self, attrname):  # only used for unknown attributes.
         if attrname == "n":
             try:
-                return self.n
-            except:
+                return self.__getattribute__(self,attrname)
+            except AttributeError:
                 return self.n_interpolated
         if attrname == "k":
             try:
-                return self.k
-            except:
+                return self.__getattribute__(self,attrname)
+            except AttributeError:
                 return self.k_interpolated
         if attrname == "electron_affinity":
             try:


### PR DESCRIPTION
This commit fixes #156, uses __getattribute__ instead of recursive __getattr__
My previous PR was sloppy, but this one is correct. Sorry for the trouble.