### PR TITLE
Update the manylinux build config for package build/deploy

### DIFF
--- a/.github/workflows/build_deploy_wheels.yml
+++ b/.github/workflows/build_deploy_wheels.yml
@@ -3,6 +3,9 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - 'fix_deploy/*'
 
 jobs:
   deploy_wheels:

--- a/.github/workflows/build_deploy_wheels.yml
+++ b/.github/workflows/build_deploy_wheels.yml
@@ -30,7 +30,7 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2014_i686
         with:
           python-versions: 'cp37-cp37m cp38-cp38'
-          build-requirements: 'numpy'
+          build-requirements: 'numpy==1.21.4'
           system-packages: 'gcc-gfortran'
           pre-build-command: 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/; export SOLCORE_WITH_PDD=1'
 


### PR DESCRIPTION
This resolves the problem highlighted in #215.

The build of the i686 manylinux packages started to fail causing the deployment workflow to fail.

The long string of errors appeared to have something to do with AVX512. I noted some changes in the [release notes for numpy 1.22](https://numpy.org/doc/stable/release/1.22.0-notes.html) relating to AVX512 and its use in vectorizing the `umath` module. I assume this issue is related to the use of numpy 1.22 in an i686 environment and, for the i686 build, I therefore set it to use numpy v1.21.4 since this was previously working with older numpy releases. This seems to resolve the issue and the i686 package build now seems to complete successfully.

**NOTE:** _The workflow configuration was previously set to only run the `deploy_wheels` workflow when making a release. This makes testing challenging. To address this, an additional rule has been added to run this workflow when pushing to branches that begin `fix_deploy/`. In this case, when running in a fork that doesn't have access to the secrets required to deploy to PyPi, the deployment of packages fails but it is at least possible to check that the building of the packages completes successfully. Happy to remove this addition in `.github/workflows/build_deploy_wheels.yml` if you prefer._

Closes #215.