### PR TITLE
Remove seemingly unnecessary parsing of material name string

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # config = ConfigParser()
 # config.read([default_config, ])
 # __version__ = config.get('Configuration', 'version')
-__version__ = '5.7.7'
+__version__ = '5.8.0'
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.7.7
+current_version = 5.8.0
 commit = True
 tag = True
 

--- a/solcore/absorption_calculator/adachi_alpha.py
+++ b/solcore/absorption_calculator/adachi_alpha.py
@@ -4,12 +4,14 @@ from solcore.constants import hbar, pi, c
 from solcore.science_tracker import science_reference
 
 
+
+
 def create_adachi_alpha(material, Esteps=(1.42, 6, 3000), T=300, wl=None):
     """ Calculates the n, k and absorption coefficient of a material using Adachi's formalism of critical points.
 
     :param material: A solcore material
     :param Esteps: (1.42, 6, 3000) A tuple with the start, end and step energies in which calculating the optical data
-    :param T: (300) Temeprature in kelvin
+    :param T: (300) Temperature in kelvin
     :param wl: (None) Optional array indicating the wavelengths in which calculating the data
     :return: A tuple containing 4 arrays: (Energy, n, k, alpha)
     """
@@ -18,27 +20,40 @@ def create_adachi_alpha(material, Esteps=(1.42, 6, 3000), T=300, wl=None):
                       'S.Adachi, “Optical dispersion relations for GaP, GaAs, GaSb, InP, InAs, InSb, AlxGa1−xAs, '
                       'and In1−xGaxAsyP1−y” J.Appl.Phys., vol.66, no.12, pp.6030–12, 1989.')
 
-    if type(material) != str:
-        material = material.plain_string()
+    # determine if material is stored in Solcore as an alloy by checking main_fraction
+    # if not, can simply look up by name. Otherwise, need to pass relevant alloy compositions also
 
-    e0 = get_parameter(material, "E0", T=T) + 0j
-    Delta0 = get_parameter(material, "E0plusD0", T=T) + 0j - e0
-    e1 = get_parameter(material, "E1", T=T) + 0j
-    Delta1 = get_parameter(material, "E1plusD1", T=T) + 0j - e1
-    e2 = get_parameter(material, "E2", T=T) + 0j
-    egid = get_parameter(material, "Eg1d", T=T) + 0j
-    a = get_parameter(material, "A", T=T) + 0j
-    b1 = get_parameter(material, "B1", T=T) + 0j
-    b11 = get_parameter(material, "B11", T=T) + 0j
-    Gamma = get_parameter(material, "Gamma", T=T) + 0j  # , "eV",T=T)
-    cc = get_parameter(material, "C", T=T) + 0j
-    gamma = get_parameter(material, "gamma", T=T) + 0j
-    d = get_parameter(material, "D", T=T) + 0j
+    if type(material) != str:
+        if material.main_fraction == 0:
+            material = material.material_string
+            alloy_args = {}
+
+        else:
+            alloy_args = {material.composition[0]: material.main_fraction}
+            material = material.material_string
+
+    # else:
+    #     alloy_args = re.split(r'([\d\.]+)', material)
+
+
+    e0 = get_parameter(material, "E0", T=T, **alloy_args) + 0j
+    Delta0 = get_parameter(material, "E0plusD0", T=T,**alloy_args) + 0j - e0
+    e1 = get_parameter(material, "E1", T=T, **alloy_args) + 0j
+    Delta1 = get_parameter(material, "E1plusD1", T=T, **alloy_args) + 0j - e1
+    e2 = get_parameter(material, "E2", T=T, **alloy_args) + 0j
+    egid = get_parameter(material, "Eg1d", T=T, **alloy_args) + 0j
+    a = get_parameter(material, "A", T=T, **alloy_args) + 0j
+    b1 = get_parameter(material, "B1", T=T, **alloy_args) + 0j
+    b11 = get_parameter(material, "B11", T=T, **alloy_args) + 0j
+    Gamma = get_parameter(material, "Gamma", T=T, **alloy_args) + 0j  # , "eV",T=T)
+    cc = get_parameter(material, "C", T=T, **alloy_args) + 0j
+    gamma = get_parameter(material, "gamma", T=T, **alloy_args) + 0j
+    d = get_parameter(material, "D", T=T, **alloy_args) + 0j
     omegaphonon = 0
     b2 = b1
     b21 = b11
 
-    a0 = get_parameter(material, "lattice_constant", T=T)
+    a0 = get_parameter(material, "lattice_constant", T=T, **alloy_args)
 
     b2 = 44 * (e1 + 2 * Delta1 / 3.) / (a0 * (e1 + Delta1) ** 2)
     b1 = 44 * (e1 + Delta1 / 3) / (a0 * e1 ** 2)

--- a/solcore/absorption_calculator/adachi_alpha.py
+++ b/solcore/absorption_calculator/adachi_alpha.py
@@ -4,8 +4,6 @@ from solcore.constants import hbar, pi, c
 from solcore.science_tracker import science_reference
 
 
-
-
 def create_adachi_alpha(material, Esteps=(1.42, 6, 3000), T=300, wl=None):
     """ Calculates the n, k and absorption coefficient of a material using Adachi's formalism of critical points.
 
@@ -31,10 +29,6 @@ def create_adachi_alpha(material, Esteps=(1.42, 6, 3000), T=300, wl=None):
         else:
             alloy_args = {material.composition[0]: material.main_fraction}
             material = material.material_string
-
-    # else:
-    #     alloy_args = re.split(r'([\d\.]+)', material)
-
 
     e0 = get_parameter(material, "E0", T=T, **alloy_args) + 0j
     Delta0 = get_parameter(material, "E0plusD0", T=T,**alloy_args) + 0j - e0

--- a/solcore/absorption_calculator/adachi_alpha.py
+++ b/solcore/absorption_calculator/adachi_alpha.py
@@ -7,7 +7,7 @@ from solcore.science_tracker import science_reference
 def create_adachi_alpha(material, Esteps=(1.42, 6, 3000), T=300, wl=None):
     """ Calculates the n, k and absorption coefficient of a material using Adachi's formalism of critical points.
 
-    :param material: A solcore material
+    :param material: A Solcore material
     :param Esteps: (1.42, 6, 3000) A tuple with the start, end and step energies in which calculating the optical data
     :param T: (300) Temperature in kelvin
     :param wl: (None) Optional array indicating the wavelengths in which calculating the data
@@ -21,14 +21,13 @@ def create_adachi_alpha(material, Esteps=(1.42, 6, 3000), T=300, wl=None):
     # determine if material is stored in Solcore as an alloy by checking main_fraction
     # if not, can simply look up by name. Otherwise, need to pass relevant alloy compositions also
 
-    if type(material) != str:
-        if material.main_fraction == 0:
-            material = material.material_string
-            alloy_args = {}
+    if material.main_fraction == 0:
+        material = material.material_string
+        alloy_args = {}
 
-        else:
-            alloy_args = {material.composition[0]: material.main_fraction}
-            material = material.material_string
+    else:
+        alloy_args = {material.composition[0]: material.main_fraction}
+        material = material.material_string
 
     e0 = get_parameter(material, "E0", T=T, **alloy_args) + 0j
     Delta0 = get_parameter(material, "E0plusD0", T=T,**alloy_args) + 0j - e0

--- a/solcore/material_system/material_system.py
+++ b/solcore/material_system/material_system.py
@@ -347,6 +347,7 @@ class BaseMaterial:
 
         kwargs = {element: getattr(self, element) for element in self.composition}
         kwargs["T"] = self.T
+
         return ParameterSystem().get_parameter(self.material_string, attrname, **kwargs)
 
     @lru_cache(maxsize=1)

--- a/solcore/parameter_system/parameter_system.py
+++ b/solcore/parameter_system/parameter_system.py
@@ -53,7 +53,7 @@ class ParameterSystem(SourceManagedClass):
             "([A-Z][a-z]*)")
 
     def get_parameter(self, material, parameter, verbose=False, **others):
-        # print('1', material)
+
         """Calculate/look up parameters for materials, returns in SI units
         
         Usage: .get_parameter(material_name, parameter_name, **kwargs)

--- a/solcore/parameter_system/parameter_system.py
+++ b/solcore/parameter_system/parameter_system.py
@@ -53,6 +53,7 @@ class ParameterSystem(SourceManagedClass):
             "([A-Z][a-z]*)")
 
     def get_parameter(self, material, parameter, verbose=False, **others):
+        # print('1', material)
         """Calculate/look up parameters for materials, returns in SI units
         
         Usage: .get_parameter(material_name, parameter_name, **kwargs)
@@ -68,7 +69,8 @@ class ParameterSystem(SourceManagedClass):
         The function is cached, so that multiple calls with the same parameters do not incur additional overhead.
         
         """
-        material, relevant_parameters = self.__parse_material_string(material, others)
+
+        relevant_parameters = others
 
         def tryget(p, alternative):
             try:
@@ -129,36 +131,38 @@ class ParameterSystem(SourceManagedClass):
         raise ValueError(
             "Parameter '{}' not in material '{}', nor in calculable parameters.".format(parameter, material))
 
-    def __parse_material_string(self, material_string, other_parameters):
-        """parses the material identifier strings of these types:
-        
-            - In0.2GaAsP0.01
-            - InGaAsP {"In":0.2, "P":0.01}
-            
-            into:
-                tuple("InGaAsP", {"In":0.2, "P":0.01})
-            
-            other parameters are passed into the fractions dictionary. Chemical element Symbols are permitted as 
-            sub-material strings, as well as longer words as long as they begin with a capital letter. 
-        """
-        if "{" in material_string:  # fractions given as a dictionary: InGaAsP {'In':0.2, 'P':0.01}
-            identifier, arguments = material_string.split(" ")
-            arguments = ast.literal_eval(arguments)
-            assert type(arguments) == dict, "{} is not a dict".format(arguments)
-            arguments.update(other_parameters)
-            return identifier, arguments
-
-        # else: fractions given in parameter or in string: In0.2GaAsP0.01
-        elements_and_fractions = self.element_RE.split(material_string)[1:]
-        arguments = {}
-        for element, fraction in grouper(elements_and_fractions, 2):
-            try:
-                arguments[element] = float(fraction)
-            except:
-                pass
-        arguments.update(other_parameters)
-        # print ("".join(elements_and_fractions[::2]),arguments )
-        return "".join(elements_and_fractions[::2]), arguments
+    # def __parse_material_string(self, material_string, other_parameters):
+    #     """parses the material identifier strings of these types:
+    #
+    #         - In0.2GaAsP0.01
+    #         - InGaAsP {"In":0.2, "P":0.01}
+    #
+    #         into:
+    #             tuple("InGaAsP", {"In":0.2, "P":0.01})
+    #
+    #         other parameters are passed into the fractions dictionary. Chemical element Symbols are permitted as
+    #         sub-material strings, as well as longer words as long as they begin with a capital letter.
+    #     """
+    #     # print('parse f', material_string)
+    #     if "{" in material_string:  # fractions given as a dictionary: InGaAsP {'In':0.2, 'P':0.01}
+    #         identifier, arguments = material_string.split(" ")
+    #         arguments = ast.literal_eval(arguments)
+    #         assert type(arguments) == dict, "{} is not a dict".format(arguments)
+    #         arguments.update(other_parameters)
+    #         return identifier, arguments
+    #
+    #
+    #     elements_and_fractions = self.element_RE.split(material_string)[1:]
+    #
+    #     arguments = {}
+    #     for element, fraction in grouper(elements_and_fractions, 2):
+    #         try:
+    #             arguments[element] = float(fraction)
+    #         except:
+    #             pass
+    #     arguments.update(other_parameters)
+    #
+    #     return "".join(elements_and_fractions[::2]), arguments
 
     def __eval_string_expression(self, string_expression, **others):
         if " " in string_expression:  # treat second part as unit!

--- a/solcore/solcore_config.txt
+++ b/solcore/solcore_config.txt
@@ -1,5 +1,5 @@
 [Configuration]
-version: 5.7.7
+version: 5.8.0
 welcome_message: 1
 verbose_loading: 1
 


### PR DESCRIPTION
Currently, when trying to get parameters using the material_system module, the `get_parameters` function parses the material string, strips out the numbers (to pass them as alloy fractions), and then tries to look up the parameter. This works as expected for Solcore built-in materials, and custom materials which do not have numbers in the name. However, if you define a custom material with numbers in the name (for instance 'Al0.8Ga0.2AsP'), providing not just the optical constant but also further material parameters like bandgaps and effective masses, an error will happen since the numbers will get stripped out and get_parameter attempts to look up parameters under the heading 'AlGaAsP', which is not in the database (and even if it was in the database, it would not be the material entry we want to get the parameter from!). 

This behaviour seems to exist so that you could define a material as something like `material('In0.1Ga0.9As')` and let Solcore figure out the alloy fractions, rather than specifying `material('InGaAs')(In=0.1)` but actually this sort of usage doesn't happen in any current tests or examples (maybe there is a historical reason for it?). Removing this step (stripping out the numbers from the material name) altogether currently only breaks the create_adachi_alpha function, which should be pretty easy to fix. I just want to make sure there isn't some deeper reason for this behaviour which I am not aware of.