### PR TITLE
Registry

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,8 @@ max-line-length = 88
 exclude = .venv/
 extend-ignore = 
 	E203,
+
+[isort]
+line_length = 88
+multi_line_output = 3
+include_trailing_comma = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,9 @@ addopts = --cov=solcore --cov-report=html:htmlcov -p no:warnings -n "auto" -v
 [bumpversion:file:solcore/solcore_config.txt]
 
 [bumpversion:file:docs/source/conf.py]
+
+[flake8]
+max-line-length = 88
+exclude = .venv/
+extend-ignore = 
+	E203,

--- a/solcore/registries.py
+++ b/solcore/registries.py
@@ -1,0 +1,50 @@
+"""Registries are dictionaries that put together Solcore's functionality that share the
+same purpose, eg. calculate solar cell properties, solve the electrical properties of
+junctions or solve their optical properties. They can also perform validation and be
+used to extend Solcore's functionality without the need of modifying the source code.
+
+The main advantage of registries is that they allow you to define your own functionality
+outside of the solcore code base, simplifying the process of trying new things:
+
+>>> from solcore import registries
+>>> @registries.register_action("pre-process")
+... def pre_process_cell(*args, **kwargs):
+...     pass
+>>> "pre-process" in registries.ACTIONS_REGISTRY
+True
+
+After this, `pre-process` will be one of the `task` that you can run when executing the
+`solar_cell_solver` funciton.
+
+You can also overwrite existing functionality in case you want to implement your own
+alternative to an existing approach:
+
+>>> from solcore import registries
+>>> @registries.register_action("optics", overwrite=True)
+... def custom_solve_optics(*args, **kwargs):
+...     pass
+>>> registries.ACTIONS_REGISTRY["optics"] == custom_solve_optics
+True
+
+"""
+from typing import Callable, Dict
+
+from .solar_cell import SolarCell
+from .state import State
+
+ACTIONS_SIGNATURE = Callable[[SolarCell, State], None]
+ACTIONS_REGISTRY: Dict[str, ACTIONS_SIGNATURE] = {}
+
+
+def register_action(name: str, overwrite: bool = False) -> Callable:
+    if name in ACTIONS_REGISTRY and not overwrite:
+        raise ValueError(
+            f"Action '{name}' already exist in the registry."
+            "Give it another name or set `overwrite = True`."
+        )
+
+    def wrap(func: ACTIONS_SIGNATURE) -> ACTIONS_SIGNATURE:
+        ACTIONS_REGISTRY[name] = func
+        return func
+
+    return wrap

--- a/solcore/solar_cell_solver.py
+++ b/solcore/solar_cell_solver.py
@@ -1,24 +1,24 @@
-import numpy as np
-
 from typing import Dict, Union
 
-import solcore.analytic_solar_cells as ASC
-from solcore.light_source import LightSource
-from solcore.state import State
-from solcore.optics import (
-    solve_beer_lambert,
-    solve_tmm,
-    solve_rcwa,
+import numpy as np
+
+from . import analytic_solar_cells as ASC
+from .absorption_calculator import RCWASolverError
+from .light_source import LightSource
+from .optics import (
     rcwa_options,
+    solve_beer_lambert,
     solve_external_optics,
+    solve_rcwa,
+    solve_tmm,
 )
-from solcore.absorption_calculator import RCWASolverError
-from solcore.structure import Layer, Junction, TunnelJunction
 from .registries import ACTIONS_REGISTRY, register_action
 from .solar_cell import SolarCell
+from .state import State
+from .structure import Junction, Layer, TunnelJunction
 
 try:
-    import solcore.poisson_drift_diffusion as PDD
+    from . import poisson_drift_diffusion as PDD
 
     a = PDD.pdd_options
 except AttributeError:

--- a/solcore/solar_cell_solver.py
+++ b/solcore/solar_cell_solver.py
@@ -1,11 +1,21 @@
 import numpy as np
 
+from typing import Dict, Union
+
 import solcore.analytic_solar_cells as ASC
 from solcore.light_source import LightSource
 from solcore.state import State
-from solcore.optics import solve_beer_lambert, solve_tmm, solve_rcwa, rcwa_options, solve_external_optics
+from solcore.optics import (
+    solve_beer_lambert,
+    solve_tmm,
+    solve_rcwa,
+    rcwa_options,
+    solve_external_optics,
+)
 from solcore.absorption_calculator import RCWASolverError
 from solcore.structure import Layer, Junction, TunnelJunction
+from .registries import ACTIONS_REGISTRY, register_action
+from .solar_cell import SolarCell
 
 try:
     import solcore.poisson_drift_diffusion as PDD
@@ -17,6 +27,7 @@ except AttributeError:
 default_options = State()
 pdd_options = PDD.pdd_options
 asc_options = ASC.db_options
+
 
 def merge_dicts(*dict_args):
     """
@@ -35,8 +46,12 @@ default_options.T = 298
 
 # Illumination spectrum
 default_options.wavelength = np.linspace(300, 1800, 251) * 1e-9
-default_options.light_source = LightSource(source_type='standard', version='AM1.5g', x=default_options.wavelength,
-                                           output_units='photon_flux_per_m')
+default_options.light_source = LightSource(
+    source_type="standard",
+    version="AM1.5g",
+    x=default_options.wavelength,
+    output_units="photon_flux_per_m",
+)
 
 # IV control
 default_options.voltages = np.linspace(0, 1.2, 100)
@@ -47,19 +62,32 @@ default_options.position = None
 default_options.radiative_coupling = False
 
 # Optics control
-default_options.optics_method = 'BL'
+default_options.optics_method = "BL"
 default_options.recalculate_absorption = False
 
-default_options = merge_dicts(default_options, ASC.db_options, ASC.da_options, PDD.pdd_options, rcwa_options)
+default_options = merge_dicts(
+    default_options, ASC.db_options, ASC.da_options, PDD.pdd_options, rcwa_options
+)
 
 
-def solar_cell_solver(solar_cell, task, user_options=None):
-    """ Solves the properties of a solar cell object, either calculating its optical properties (R, A and T), its quantum efficiency or its current voltage characteristics in the dark or under illumination. The general options for the solvers are passed as dictionaries.
+def solar_cell_solver(
+    solar_cell: SolarCell, task: str, user_options: Union[Dict, State, None] = None
+):
+    """Solves the properties of a solar cell object
 
-    :param solar_cell: A solar_cell object
-    :param task: Task to perform. It has to be "optics", "iv", "qe", "equilibrium" or "short_circuit". The last two only work for PDD junctions
-    :param user_options: A dictionary containing the options for the solver, which will overwrite the default options.
-    :return: None
+    This can be done either calculating its optical properties (R, A and T), its quantum
+    efficiency or its current voltage characteristics in the dark or under illumination.
+    The general options for the solvers are passed as dictionaries or state objects.
+
+    Args:
+        - solar_cell: A solar_cell object
+        - taks: Task to perform. Some of the existing tasks might not be available for
+          all types of junctions.
+        - user_options: A dictionary containing the options for the solver, which will
+          overwrite the default options.
+
+    Return:
+        None
     """
     if type(user_options) in [State, dict]:
         options = merge_dicts(default_options, user_options)
@@ -69,23 +97,19 @@ def solar_cell_solver(solar_cell, task, user_options=None):
     prepare_solar_cell(solar_cell, options)
     options.T = solar_cell.T
 
-    if task == 'optics':
-        solve_optics(solar_cell, options)
-    elif task == 'iv':
-        solve_iv(solar_cell, options)
-    elif task == 'qe':
-        solve_qe(solar_cell, options)
-    elif task == 'equilibrium':
-        solve_equilibrium(solar_cell, options)
-    elif task == 'short_circuit':
-        solve_short_circuit(solar_cell, options)
-    else:
+    action = ACTIONS_REGISTRY.get(task, None)
+    if action is None:
         raise ValueError(
-            'ERROR in "solar_cell_solver":\n\tValid values for "task" are: "optics", "iv", "qe", "equilibrium" and "short_circuit".')
+            "ERROR in 'solar_cell_solver' - Valid tasks are "
+            f"'{list(ACTIONS_REGISTRY.keys())}'."
+        )
+
+    action(solar_cell, options)
 
 
+@register_action("optics")
 def solve_optics(solar_cell, options):
-    """ Solves the optical properties of the structure, calculating the reflectance, absorptance and transmitance. The "optics_method" option controls which method is used to calculate the optical properties of the solar cell:
+    """Solves the optical properties of the structure, calculating the reflectance, absorptance and transmitance. The "optics_method" option controls which method is used to calculate the optical properties of the solar cell:
 
     - None: The calculation is skipped. Only useful for solar cells involving just "2-diode" kind of junctions.
     - BL: Uses the Beer-Lambert law to calculate the absorption in each layer. Front surface reflexion has to provided externally. It is the default method and the most flexible one.
@@ -97,36 +121,44 @@ def solve_optics(solar_cell, options):
     :param options: Options for the optics solver
     :return: None
     """
-    print('Solving optics of the solar cell...')
+    print("Solving optics of the solar cell...")
 
-    calculated = hasattr(solar_cell[0], 'absorbed')
-    recalc = options.recalculate_absorption if 'recalculate_absorption' in options.keys() else False
+    calculated = hasattr(solar_cell[0], "absorbed")
+    recalc = (
+        options.recalculate_absorption
+        if "recalculate_absorption" in options.keys()
+        else False
+    )
     if not calculated or recalc:
 
         if options.optics_method is None:
-            print('Warning: Not solving the optics of the solar cell.')
-        elif options.optics_method == 'external':
+            print("Warning: Not solving the optics of the solar cell.")
+        elif options.optics_method == "external":
             solve_external_optics(solar_cell, options)
-        elif options.optics_method == 'BL':
+        elif options.optics_method == "BL":
             solve_beer_lambert(solar_cell, options)
-        elif options.optics_method == 'TMM':
+        elif options.optics_method == "TMM":
             solve_tmm(solar_cell, options)
-        elif options.optics_method == 'RCWA':
+        elif options.optics_method == "RCWA":
             if solve_rcwa is not None:
                 solve_rcwa(solar_cell, options)
             else:
                 raise RCWASolverError("RCWA optical solver not available!!")
         else:
             raise ValueError(
-                'ERROR in "solar_cell_solver":\n\tOptics solver method must be None, "external", "BL", "TMM" or "RCWA".')
+                'ERROR in "solar_cell_solver":\n\tOptics solver method must be None, "external", "BL", "TMM" or "RCWA".'
+            )
 
     else:
-        print('Already calculated reflection, transmission and absorption profile - not recalculating. '
-              'Set recalculate_absorption to True in the options if you want absorption to be calculated again.')
+        print(
+            "Already calculated reflection, transmission and absorption profile - not recalculating. "
+            "Set recalculate_absorption to True in the options if you want absorption to be calculated again."
+        )
 
 
+@register_action("iv")
 def solve_iv(solar_cell, options):
-    """ Calculates the IV at a given voltage range, providing the IVs of the individual junctions in addition to the total IV
+    """Calculates the IV at a given voltage range, providing the IVs of the individual junctions in addition to the total IV
 
     :param solar_cell: A solar_cell object
     :param options: Options for the solvers
@@ -134,48 +166,55 @@ def solve_iv(solar_cell, options):
     """
     solve_optics(solar_cell, options)
 
-    print('Solving IV of the junctions...')
+    print("Solving IV of the junctions...")
 
     for j in solar_cell.junction_indices:
 
-        if solar_cell[j].kind == 'PDD':
+        if solar_cell[j].kind == "PDD":
             PDD.iv_pdd(solar_cell[j], options)
-        elif solar_cell[j].kind == 'DA':
+        elif solar_cell[j].kind == "DA":
             ASC.iv_depletion(solar_cell[j], options)
-        elif solar_cell[j].kind == '2D':
+        elif solar_cell[j].kind == "2D":
             ASC.iv_2diode(solar_cell[j], options)
-        elif solar_cell[j].kind == 'DB':
+        elif solar_cell[j].kind == "DB":
             ASC.iv_detailed_balance(solar_cell[j], options)
         else:
             raise ValueError(
                 'ERROR in "solar_cell_solver":\n\tJunction {} has an invalid "type". It must be "PDD", "DA", "2D" or "DB".'.format(
-                    j))
+                    j
+                )
+            )
 
-    print('Solving IV of the tunnel junctions...')
+    print("Solving IV of the tunnel junctions...")
     for j in solar_cell.tunnel_indices:
 
-        if solar_cell[j].kind == 'resistive':
+        if solar_cell[j].kind == "resistive":
             # The tunnel junction is modeled as a simple resistor
             ASC.resistive_tunnel_junction(solar_cell[j], options)
-        elif solar_cell[j].kind == 'parametric':
+        elif solar_cell[j].kind == "parametric":
             # The tunnel junction is modeled using a simple parametric model
             ASC.parametric_tunnel_junction(solar_cell[j], options)
-        elif solar_cell[j].kind == 'external':
+        elif solar_cell[j].kind == "external":
             # The tunnel junction is modeled using a simple parametric model
             ASC.external_tunnel_junction(solar_cell[j], options)
-        elif solar_cell[j].kind == 'analytic':
-            print('Sorry, the analytical tunnel junction model is not implemented, yet.')
+        elif solar_cell[j].kind == "analytic":
+            print(
+                "Sorry, the analytical tunnel junction model is not implemented, yet."
+            )
         else:
             raise ValueError(
                 'ERROR in "solar_cell_solver":\n\tTunnel junction {} has an invalid "type". It must be "parametric", "analytic", "external" or "resistive".'.format(
-                    j))
+                    j
+                )
+            )
 
-    print('Solving IV of the total solar cell...')
+    print("Solving IV of the total solar cell...")
     ASC.iv_multijunction(solar_cell, options)
 
 
+@register_action("qe")
 def solve_qe(solar_cell, options):
-    """ Calculates the QE of all the junctions
+    """Calculates the QE of all the junctions
 
     :param solar_cell: A solar_cell object
     :param options: Options for the solvers
@@ -184,27 +223,30 @@ def solve_qe(solar_cell, options):
 
     solve_optics(solar_cell, options)
 
-    print('Solving QE of the solar cell...')
+    print("Solving QE of the solar cell...")
     for j in solar_cell.junction_indices:
-        if solar_cell[j].kind == 'PDD':
+        if solar_cell[j].kind == "PDD":
             PDD.qe_pdd(solar_cell[j], options)
-        elif solar_cell[j].kind == 'DA':
+        elif solar_cell[j].kind == "DA":
             ASC.qe_depletion(solar_cell[j], options)
-        elif solar_cell[j].kind == '2D':
+        elif solar_cell[j].kind == "2D":
             # We solve this case as if it were DB. Therefore, to work it needs the same inputs in the Junction object
             wl = options.wavelength
             ASC.qe_detailed_balance(solar_cell[j], wl)
-        elif solar_cell[j].kind == 'DB':
+        elif solar_cell[j].kind == "DB":
             wl = options.wavelength
             ASC.qe_detailed_balance(solar_cell[j], wl)
         else:
             raise ValueError(
                 'ERROR in "solar_cell_solver":\n\tJunction {} has an invalid "type". It must be "PDD", "DA", "2D" or "DB".'.format(
-                    j))
+                    j
+                )
+            )
 
 
+@register_action("equilibrium")
 def solve_equilibrium(solar_cell, options):
-    """ Uses the PDD solver to calculate the properties of all the all the junctions under equilibrium
+    """Uses the PDD solver to calculate the properties of all the all the junctions under equilibrium
 
     :param solar_cell: A solar_cell object
     :param options: Options for the solvers
@@ -212,14 +254,15 @@ def solve_equilibrium(solar_cell, options):
     """
     for j in solar_cell.junction_indices:
 
-        if solar_cell[j].kind == 'PDD':
+        if solar_cell[j].kind == "PDD":
             PDD.equilibrium_pdd(solar_cell[j], options)
         else:
             print('WARNING: Only PDD junctions can be solved in "equilibrium".')
 
 
+@register_action("short_circuit")
 def solve_short_circuit(solar_cell, options):
-    """ Uses the PDD solver to calculate the properties of all the all the junctions under short circuit
+    """Uses the PDD solver to calculate the properties of all the all the junctions under short circuit
 
     :param solar_cell: A solar_cell object
     :param options: Options for the solvers
@@ -230,14 +273,14 @@ def solve_short_circuit(solar_cell, options):
 
     for j in solar_cell.junction_indices:
 
-        if solar_cell[j].kind == 'PDD':
+        if solar_cell[j].kind == "PDD":
             PDD.short_circuit_pdd(solar_cell[j], options)
         else:
             print('WARNING: Only PDD junctions can be solved in "short_circuit".')
 
 
 def prepare_solar_cell(solar_cell, options):
-    """ This function scans all the layers and junctions of the cell, calculating the relative position of each of them with respect the front surface (offset).
+    """This function scans all the layers and junctions of the cell, calculating the relative position of each of them with respect the front surface (offset).
     This information will later be use by the optical calculators, for example. It also processes the 'position' option, which determines the spacing used if the
     solver is going to calculate depth-dependent absorption.
 
@@ -267,14 +310,16 @@ def prepare_solar_cell(solar_cell, options):
             try:
                 kind = solar_cell[j].kind
             except AttributeError as err:
-                print('ERROR preparing the solar cell: Junction {} has no kind!'.format(j))
+                print(
+                    "ERROR preparing the solar cell: Junction {} has no kind!".format(j)
+                )
                 raise err
 
             # This junctions will not, typically, have a width
-            if kind in ['2D', 'DB']:
+            if kind in ["2D", "DB"]:
                 layer_widths.append(1e-6)
                 # 2D and DB junctions do not often have a width (or need it) so we set an arbitrary width
-                if not hasattr(layer_object, 'width'):
+                if not hasattr(layer_object, "width"):
                     solar_cell[j].width = 1e-6  # 1 µm
 
             else:
@@ -292,7 +337,6 @@ def prepare_solar_cell(solar_cell, options):
     process_position(solar_cell, options, layer_widths)
 
 
-
 def process_position(solar_cell, options, layer_widths):
     """
     To control the depth spacing, the user can pass:
@@ -308,13 +352,19 @@ def process_position(solar_cell, options, layer_widths):
     """
 
     if options.position is None:
-        options.position = [max(1e-10, width/5000) for width in layer_widths]
+        options.position = [max(1e-10, width / 5000) for width in layer_widths]
 
         layer_offsets = np.insert(np.cumsum(layer_widths), 0, 0)
-        options.position = np.hstack([np.arange(layer_offsets[j],
-                                                layer_offsets[j] + layer_width,
-                                                options.position[j]) for j, layer_width
-                                      in enumerate(layer_widths)])
+        options.position = np.hstack(
+            [
+                np.arange(
+                    layer_offsets[j],
+                    layer_offsets[j] + layer_width,
+                    options.position[j],
+                )
+                for j, layer_width in enumerate(layer_widths)
+            ]
+        )
 
     elif isinstance(options.position, int) or isinstance(options.position, float):
         options.position = np.arange(0, solar_cell.width, options.position)
@@ -324,8 +374,26 @@ def process_position(solar_cell, options, layer_widths):
             options.position = np.arange(0, solar_cell.width, options.position[0])
 
         if len(options.position) == len(solar_cell):
-            options.position = np.hstack([np.arange(layer_object.offset, layer_object.offset + layer_object.width, options.position[j]) for j, layer_object in enumerate(solar_cell)])
+            options.position = np.hstack(
+                [
+                    np.arange(
+                        layer_object.offset,
+                        layer_object.offset + layer_object.width,
+                        options.position[j],
+                    )
+                    for j, layer_object in enumerate(solar_cell)
+                ]
+            )
 
         elif len(options.position) == len(layer_widths):
             layer_offsets = np.insert(np.cumsum(layer_widths), 0, 0)
-            options.position = np.hstack([np.arange(layer_offsets[j], layer_offsets[j] + layer_width, options.position[j]) for j, layer_width in enumerate(layer_widths)])
+            options.position = np.hstack(
+                [
+                    np.arange(
+                        layer_offsets[j],
+                        layer_offsets[j] + layer_width,
+                        options.position[j],
+                    )
+                    for j, layer_width in enumerate(layer_widths)
+                ]
+            )

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -13,11 +13,11 @@ def test_register_action():
     with pytest.raises(ValueError):
 
         @registries.register_action("pre-process")
-        def custom_solve_optics(*args, **kwargs):
+        def custom_pre_process_cell(*args, **kwargs):
             pass
 
-    @registries.register_action("optics", overwrite=True)
-    def custom_solve_optics(*args, **kwargs):
+    @registries.register_action("pre-process", overwrite=True)
+    def another_pre_process_cell(*args, **kwargs):
         pass
 
-    assert registries.ACTIONS_REGISTRY["optics"] == custom_solve_optics
+    assert registries.ACTIONS_REGISTRY["pre-process"] == another_pre_process_cell

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+def test_register_action():
+    from solcore import registries
+
+    @registries.register_action("pre-process")
+    def pre_process_cell(*args, **kwargs):
+        pass
+
+    assert "pre-process" in registries.ACTIONS_REGISTRY
+
+    with pytest.raises(ValueError):
+
+        @registries.register_action("pre-process")
+        def custom_solve_optics(*args, **kwargs):
+            pass
+
+    @registries.register_action("optics", overwrite=True)
+    def custom_solve_optics(*args, **kwargs):
+        pass
+
+    assert registries.ACTIONS_REGISTRY["optics"] == custom_solve_optics


### PR DESCRIPTION
This PR starts the refactoring of the code in `solar_cell_solver.py` such that it uses registered functions within a set of registries to execute different calculations rather than hardcoding the functionality. 

Among other things, using registries enables:
- Checking externally what options are available (eg. by tools like `sunglass`)
- Expanding the existing functionality with new one without editing Solcore's source code.
- Overwriting existing functionality with custom versions of it to try alternative implementations, again without modifying the source code.

This PR concerns the implementation of the top level ACTIONS of the solar cell solver. PRs for the optical, IV, QE, etc. solvers will follow.

There seems to be lot's of changes because the `solar_cell_solver.py` file got reformatted by `black`, but the only important bit in that file is the function `solve_solar_cell`.