### PR TITLE
[ENH] RCWA test are skipped if S4 not intalled 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,3 +229,17 @@ def light_source(wavelength):
         output_units="photon_flux_per_m",
         concentration=1,
     )
+
+
+def skip_s4_test():
+    """
+     Utility function for skipping the test if S4 is not installed,
+
+    Returns: True if S4 not installed False otherwise
+    """
+
+    try:
+        import S4
+        return False
+    except ModuleNotFoundError:
+        return True

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -1,7 +1,5 @@
-import sys
+from .conftest import skip_s4_test
 from pytest import mark, approx
-
-from tests.conftest import skip_s4_test
 
 
 @mark.skipif(skip_s4_test(), reason="Only works if S4 installed")

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -1,8 +1,10 @@
 import sys
 from pytest import mark, approx
 
+from tests.conftest import skip_s4_test
 
-@mark.skipif(sys.platform in ["win32", "cygwin"], reason="Only works under unix based  systems")
+
+@mark.skipif(skip_s4_test(), reason="Only works if S4 installed")
 def test_calculate_rat_rcwa():
     import numpy as np
 
@@ -32,7 +34,7 @@ def test_calculate_rat_rcwa():
         assert v.shape[0] == len(wl)
 
 
-@mark.skipif(sys.platform in ["win32", "cygwin"], reason="Only works under unix based  systems")
+@mark.skipif(skip_s4_test(), reason="Only works if S4 installed")
 def test_calculate_absorption_profile_rcwa():
     import numpy as np
 
@@ -75,7 +77,7 @@ def test_calculate_absorption_profile_rcwa():
     assert result["absorption"] == approx(parallel_result["absorption"], abs=1e-5)
 
 
-@mark.skipif(sys.platform in ["win32", "cygwin"], reason="Only works under unix based  systems")
+@mark.skipif(skip_s4_test(), reason="Only works if S4 installed")
 def test_pol_rcwa():
     import numpy as np
 
@@ -131,7 +133,7 @@ def test_pol_rcwa():
     assert result_u["absorption"] == approx(0.5*(result_s["absorption"] + result_p["absorption"]))
 
 
-@mark.skipif(sys.platform in ["win32", "cygwin"], reason="Only works under unix based  systems")
+@mark.skipif(skip_s4_test(), reason="Only works if S4 installed")
 def test_arbitrary_pol_rcwa():
     import numpy as np
 
@@ -179,7 +181,7 @@ def test_arbitrary_pol_rcwa():
     assert result["absorption"] == approx(result_s["absorption"])
 
 
-@mark.skipif(sys.platform in ["win32", "cygwin"], reason="Only works under unix based  systems")
+@mark.skipif(skip_s4_test(), reason="Only works if S4 installed")
 def test_rcwa_polygon():
     import numpy as np
 
@@ -241,7 +243,7 @@ def test_rcwa_polygon():
     assert result_polygon["absorption"] == approx(result_square["absorption"], abs=0.001)
 
 
-@mark.skipif(sys.platform in ["win32", "cygwin"], reason="Only works under unix based  systems")
+@mark.skipif(skip_s4_test(), reason="Only works if S4 installed")
 @mark.parametrize("pol", ['s', 'p', 'u'])
 @mark.parametrize("angle", [0, 60])
 def test_tmm_rcwa_structure_comparison(pol, angle):
@@ -285,7 +287,7 @@ def test_tmm_rcwa_structure_comparison(pol, angle):
     assert np.sum(rcwa_result['A_per_layer'], 1) + rcwa_result['R'] + rcwa_result['T'] == approx(1)
 
 
-@mark.skipif(sys.platform in ["win32", "cygwin"], reason="Only works under unix based  systems")
+@mark.skipif(skip_s4_test(), reason="Only works if S4 installed")
 @mark.parametrize("pol", ['s', 'p', 'u'])
 @mark.parametrize("angle", [0, 60])
 def test_tmm_rcwa_structure_profile_comparison(pol, angle):


### PR DESCRIPTION
Solving the issue #241.

Create a function in `conftest.py` probably not the cleanest place, should go inside something like `test/utils` but don't know if there will be more function inside :man_shrugging: 

Tested:
![image](https://user-images.githubusercontent.com/6976921/218247425-e55cd72a-2a5a-49ca-988a-79e93c0ebf68.png)