### PR TITLE
Deploy wheels to PyPI when pushing tags

### DIFF
--- a/.github/workflows/build_deploy_wheels.yml
+++ b/.github/workflows/build_deploy_wheels.yml
@@ -87,14 +87,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-
-      - name: Install twine
-        run: pip install twine
-
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
@@ -102,7 +94,6 @@ jobs:
 
       - name: Move wheels to dist directory
         run: |
-          shopt -s globstar
           mkdir dist
           cp wheelhouse/**/*.whl dist
           ls dist/

--- a/.github/workflows/build_deploy_wheels.yml
+++ b/.github/workflows/build_deploy_wheels.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - develop
+    tags:
+      - "**"
 
 jobs:
 
-  deploy_wheels:
+  build_wheels:
     runs-on: ${{ matrix.buildplat[0] }}
     strategy:
       # Ensure that a wheel builder finishes even if another fails
@@ -75,15 +77,33 @@ jobs:
           CIBW_BEFORE_BUILD_MACOS: bash {project}/build_tools/cibw_before_build_macos_arm.sh && meson setup --cross-file={project}/build_tools/x86_64-w64-arm64.ini build
           CIBW_CONFIG_SETTINGS_MACOS: builddir=build
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
+          path: ./wheelhouse/*.whl
+
+  upload_wheels:
+    needs: build_wheels
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Install twine
+        run: pip install twine
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
       - name: Publish wheels to PyPI
         if: startsWith(github.ref, 'refs/tags')
         env:
           TWINE_USERNAME: '__token__'
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          twine upload dist/*.whl --skip-existing
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
-          path: ./wheelhouse/*.whl
+        run: twine upload */*.whl --skip-existing

--- a/.github/workflows/build_deploy_wheels.yml
+++ b/.github/workflows/build_deploy_wheels.yml
@@ -97,13 +97,20 @@ jobs:
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
+        with:
+          path: wheelhouse
 
-      - name: Display structure of downloaded files
-        run: ls -R
+      - name: Move wheels to dist directory
+        run: |
+          shopt -s globstar
+          mkdir dist
+          cp wheelhouse/**/*.whl dist
+          ls dist/
 
-      - name: Publish wheels to PyPI
-        if: startsWith(github.ref, 'refs/tags')
-        env:
-          TWINE_USERNAME: '__token__'
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: twine upload */*.whl --skip-existing
+      - name: Publish package
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: dist/
+          skip_existing: true

--- a/.github/workflows/build_deploy_wheels.yml
+++ b/.github/workflows/build_deploy_wheels.yml
@@ -102,6 +102,6 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.PYPI_TOKEN }}
           packages_dir: dist/
           skip_existing: true


### PR DESCRIPTION
The current deploy workflow was obsolete and it was not being triggered when pushing tags to the repo, which is precisely the condition required to trigger the upload. So, it was an impossible situation. 

This PR adds pushing tags as a trigger of the workflow and separates the publishing step as a separate job, using `download-artefact` and `gh-action-pypi-publish` actions to make the process more robust.