### PR TITLE
Pin devpy and update commands to v0.1 API

### DIFF
--- a/.devpy/cmds.py
+++ b/.devpy/cmds.py
@@ -1,6 +1,6 @@
 import click
 from devpy import util
-from devpy.cmds.util import get_site_packages, set_pythonpath, run
+from devpy.cmds.meson import _get_site_packages, _set_pythonpath
 
 
 @click.command()
@@ -25,19 +25,19 @@ def install_dependencies(test_dep=False, doc_dep=False):
     config = util.get_config()
     default_dependencies = config["project"]['dependencies']
     print("Installing dependencies", default_dependencies)
-    run(
+    util.run(
         ["pip", "install"] + list(default_dependencies),
     )
     if test_dep:
         test_dependencies = config["project.optional-dependencies"]['test']
         print("Installing test-dependencies", test_dependencies)
-        run(
+        util.run(
             ["pip", "install"] + list(test_dependencies),
         )
     if doc_dep:
         doc_dependencies = config["project.optional-dependencies"]['doc']
         print("Installing doc-dependencies", doc_dependencies)
-        run(
+        util.run(
             ["pip", "install"] + list(doc_dependencies),
         )
 
@@ -60,9 +60,9 @@ def codecov(build_dir, codecov_args):
         codecov parameters
     """
 
-    site_path = get_site_packages(build_dir)
+    site_path = _get_site_packages()
 
-    run(
+    util.run(
         ["codecov"] + list(codecov_args),
         cwd=site_path,
     )

--- a/.github/workflows/test_unit_and_examples.yml
+++ b/.github/workflows/test_unit_and_examples.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install Python dependecies
         run: |
-          pip install pytest meson-python ninja cython numpy git+https://github.com/scientific-python/devpy
+          pip install pytest meson-python ninja cython numpy git+https://github.com/scientific-python/devpy@v0.1
           python3 -m devpy install-dependencies -test-dep
 
       - name: Install S4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = ["pre-commit"]
 package = 'solcore'
 
 [tool.devpy.commands]
-"Build" = ["devpy.build", "devpy.test"]
+"Build" = ["devpy.cmds.meson.build", "devpy.cmds.meson.test"]
 "Extensions" = ['.devpy/cmds.py:codecov', '.devpy/cmds.py:install_dependencies']
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Please note that `devpy` will soon be renamed to `spin` due to PyPi name availability.