### PR TITLE
Speed up coh_tmm in tmm_core_vec; introduced versions with cpu and gpu parallelization

### DIFF
--- a/solcore/absorption_calculator/tmm_core_cpu_parallel.py
+++ b/solcore/absorption_calculator/tmm_core_cpu_parallel.py
@@ -1,0 +1,259 @@
+"""
+This is implementation of the coh_tmm function using numba jit (CPU parallelization)
+For large number of calculations (e.g. s and p polarization, 10,000 wavelengths x angles)
+the speed increase over tmm_core_vec implementation is signficant, execution time @ 35% 
+(tested with 24 cores)
+if further set detailed = False, will skip calculations of power_entering 
+and vw_list, and the function will be faster still, execution time roughly 85% x 35% = 30%
+Note however that the first time the function executes, the jit will consume a lot of time,
+so the speed increase is only observed after an initial run
+"""
+
+import numpy as np
+import sys
+from numba import jit
+
+EPSILON = sys.float_info.epsilon  # typical floating-point calculation error
+
+def make_2x2_array(a, b, c, d, dtype=float):
+    """
+    Makes a 2x2 numpy array of [[a,b],[c,d]]
+
+    Same as "numpy.array([[a,b],[c,d]], dtype=float)", but ten times faster
+    """
+    my_array = np.empty((len(a), 2, 2), dtype=dtype)
+    my_array[:, 0, 0] = a
+    my_array[:, 0, 1] = b
+    my_array[:, 1, 0] = c
+    my_array[:, 1, 1] = d
+    return my_array
+
+@jit(nopython=True, parallel=True)
+def list_snell(n_list, th_0):
+    """
+    return list of angle theta in each layer based on angle th_0 in layer 0,
+    using Snell's law. n_list is index of refraction of each layer. Note that
+    "angles" may be complex!!
+    """
+    # Important that the arcsin here is scipy.arcsin, not numpy.arcsin!! (They
+    # give different results e.g. for arcsin(2).)
+    # Use real_if_close because e.g. arcsin(2 + 1e-17j) is very different from
+    # arcsin(2) due to branch cut
+    # Note: scipy.arcsin is deprecated, hence scimath replacement
+    return np.arcsin(n_list[0] * np.sin(th_0) / n_list)
+
+@jit(nopython=True, parallel=True)
+def power_entering_from_r(pol, r, n_i, cos_th_i):
+    """
+    Calculate the power entering the first interface of the stack, starting with
+    reflection amplitude r. Normally this equals 1-R, but in the unusual case
+    that n_i is not real, it can be a bit different than 1-R. See manual.
+
+    n_i is refractive index of incident medium.
+
+    th_i is (complex) propegation angle through incident medium
+    (in radians, where 0=normal). "th" stands for "theta".
+    """
+    if (pol == 's'):
+        return ((n_i * cos_th_i * (1 + np.conj(r)) * (1 - r)).real
+                / (n_i * cos_th_i).real)
+    elif (pol == 'p'):
+        return ((n_i * np.conj(cos_th_i) * (1 + r) * (1 - np.conj(r))).real
+                / (n_i * np.conj(cos_th_i)).real)
+    else:
+        raise ValueError("Polarization must be 's' or 'p'")
+
+@jit(nopython=True, parallel=True)
+def construct_r_t_list(n_list, cos_th_list, pol, r_list, t_list):
+    if pol == 's':
+        t_list[:,:-1] = np.transpose((2 * n_list[:-1] * cos_th_list[:-1]) /
+                (n_list[:-1] * cos_th_list[:-1] + n_list[1:] * cos_th_list[1:]))
+        r_list[:,:-1] = np.transpose((n_list[:-1] * cos_th_list[:-1] - n_list[1:] * cos_th_list[1:]) /
+                (n_list[:-1] * cos_th_list[:-1] + n_list[1:] * cos_th_list[1:]))
+    else:
+        t_list[:,:-1] = np.transpose((2 * n_list[:-1] * cos_th_list[:-1]) /
+                (n_list[1:] * cos_th_list[:-1] + n_list[:-1] * cos_th_list[1:]))
+        r_list[:,:-1] = np.transpose((n_list[1:] * cos_th_list[:-1] - n_list[:-1] * cos_th_list[1:]) /
+                (n_list[1:] * cos_th_list[:-1] + n_list[:-1] * cos_th_list[1:]))
+
+@jit(nopython=True, parallel=True)
+def construct_M_list(num_layers, delta, r_list, t_list, M_list):
+    for i in range(0, num_layers - 1):
+        exp_ = np.exp(-1j * delta[i])
+        d = 1/t_list[:,i]
+        M_list[i,:,0,0] = exp_*d
+        M_list[i,:,0,1] = exp_*d*r_list[:, i]
+        M_list[i,:,1,0] = d/exp_*r_list[:, i]
+        M_list[i,:,1,1] = d/exp_
+
+@jit(nopython=True, parallel=True)
+def construct_Mtilde(num_layers, M_list, Mtilde):
+    for i in range(0, num_layers - 1):
+        M_00 = Mtilde[:,0,0]*M_list[i,:,0,0] + Mtilde[:,0,1]*M_list[i,:,1,0]
+        M_01 = Mtilde[:,0,0]*M_list[i,:,0,1] + Mtilde[:,0,1]*M_list[i,:,1,1]
+        M_10 = Mtilde[:,1,0]*M_list[i,:,0,0] + Mtilde[:,1,1]*M_list[i,:,1,0]
+        M_11 = Mtilde[:,1,0]*M_list[i,:,0,1] + Mtilde[:,1,1]*M_list[i,:,1,1]
+        
+        Mtilde[:,0,0] = M_00
+        Mtilde[:,0,1] = M_01
+        Mtilde[:,1,0] = M_10
+        Mtilde[:,1,1] = M_11
+
+@jit(nopython=True, parallel=True)
+def construct_r_t_R_T(Mtilde, pol, n_i, n_f, cos_th_i, cos_th_f):
+    r = Mtilde[:, 1, 0] / Mtilde[:, 0, 0]
+    t = np.ones_like(Mtilde[:, 0, 0]) / Mtilde[:, 0, 0]
+    R = np.abs(r) ** 2
+    if (pol == 's'):
+        T = np.abs(t ** 2) * (((n_f * cos_th_f).real) / (n_i * cos_th_i).real)
+    else:
+        T = np.abs(t ** 2) * (((n_f * np.conj(cos_th_f)).real) /
+                              (n_i * np.conj(cos_th_i)).real)
+    return r, t, R, T
+
+@jit(nopython=True, parallel=True)
+def construct_vw(num_layers, M_list, vw, vw_list):
+    for i in range(num_layers - 2, 0, -1):
+        M_00 = M_list[i,:,0,0]*vw[:,0,0] + M_list[i,:,0,1]*vw[:,1,0]
+        M_01 = M_list[i,:,0,0]*vw[:,0,1] + M_list[i,:,0,1]*vw[:,1,1]
+        M_10 = M_list[i,:,1,0]*vw[:,0,0] + M_list[i,:,1,1]*vw[:,1,0]
+        M_11 = M_list[i,:,1,0]*vw[:,0,1] + M_list[i,:,1,1]*vw[:,1,1]
+        
+        vw[:,0,0] = M_00
+        vw[:,0,1] = M_01
+        vw[:,1,0] = M_10
+        vw[:,1,1] = M_11
+        vw_list[i, :, :] = vw[:, :, 1]
+    vw_list[-1, :, 1] = 0
+        
+def coh_tmm(pol, n_list, d_list, th_0, lam_vac, detailed=True):
+    """
+    This function is vectorized.
+    Main "coherent transfer matrix method" calc. Given parameters of a stack,
+    calculates everything you could ever want to know about how light
+    propagates in it. (If performance is an issue, you can delete some of the
+    calculations without affecting the rest.)
+
+    pol is light polarization, "s" or "p".
+
+    n_list is the list of refractive indices, in the order that the light would
+    pass through them. The 0'th element of the list should be the semi-infinite
+    medium from which the light enters, the last element should be the semi-
+    infinite medium to which the light exits (if any exits).
+
+    th_0 is the angle of incidence: 0 for normal, pi/2 for glancing.
+    Remember, for a dissipative incoming medium (n_list[0] is not real), th_0
+    should be complex so that n0 sin(th0) is real (intensity is constant as
+    a function of lateral position).
+
+    d_list is the list of layer thicknesses (front to back). Should correspond
+    one-to-one with elements of n_list. First and last elements should be "inf".
+
+    lam_vac is vacuum wavelength of the light.
+
+    Outputs the following as a dictionary (see manual for details)
+
+    * r--reflection amplitude
+    * t--transmission amplitude
+    * R--reflected wave power (as fraction of incident)
+    * T--transmitted wave power (as fraction of incident)
+    * power_entering--Power entering the first layer, usually (but not always)
+      equal to 1-R (see manual).
+    * vw_list-- n'th element is [v_n,w_n], the forward- and backward-traveling
+      amplitudes, respectively, in the n'th medium just after interface with
+      (n-1)st medium.
+    * kz_list--normal component of complex angular wavenumber for
+      forward-traveling wave in each layer.
+    * th_list--(complex) propagation angle (in radians) in each layer
+    * pol, n_list, d_list, th_0, lam_vac--same as input
+
+    """
+    # convert lists to numpy arrays if they're not already.
+    n_list = np.array(n_list)
+    d_list = np.array(d_list, dtype=float)[:, None]
+    d_list[0] = 0.0
+    d_list[-1] = 0.0
+    d_list = d_list.astype(complex)
+
+    # input tests
+    # if hasattr(th_0, 'size') and th_0.size > 1 and th_0.size != lam_vac.size:
+    #     raise ValueError('This function is not vectorized for angles; you need to run one angle calculation at a time.')
+    # if n_list.shape[0] != d_list.shape[0]:
+    #     raise ValueError("Problem with n_list or d_list!")
+    # if (d_list[0] != np.inf) or (d_list[-1] != np.inf):
+    #     raise ValueError('d_list must start and end with inf!')
+    # if any(abs((n_list[0] * np.sin(th_0)).imag) > 100 * EPSILON):
+    #     raise ValueError('Error in n0 or th0!')
+    if hasattr(th_0, 'size'):
+        th_0 = np.array(th_0)
+    num_layers = n_list.shape[0]
+    num_wl = n_list.shape[1]
+
+    # th_list is a list with, for each layer, the angle that the light travels
+    # through the layer. Computed with Snell's law. Note that the "angles" may be
+    # complex!
+    th_list = list_snell(n_list, th_0)
+    cos_th_0 = np.cos(th_0)
+    cos_th_list = np.cos(th_list)
+
+    # kz is the z-component of (complex) angular wavevector for forward-moving
+    # wave. Positive imaginary part means decaying.
+    kz_list = 2 * np.pi * n_list * cos_th_list / lam_vac
+
+    # delta is the total phase accrued by traveling through a given layer.
+    # ignore warning about inf multiplication
+    olderr = np.seterr(invalid='ignore')
+    delta = kz_list * d_list
+    np.seterr(**olderr)
+
+    # For a very opaque layer, reset delta to avoid divide-by-0 and similar
+    # errors. The criterion imag(delta) > 35 corresponds to single-pass
+    # transmission < 1e-30 --- small enough that the exact value doesn't
+    # matter.
+    # It DOES matter (for depth-dependent calculations!)
+    delta[1:num_layers - 1, :] = np.where(delta[1:num_layers - 1, :].imag > 100, delta[1:num_layers - 1, :].real + 100j,
+                                          delta[1:num_layers - 1, :])
+
+    # t_list[i,j] and r_list[i,j] are transmission and reflection amplitudes,
+    # respectively, coming from i, going to j. Only need to calculate this when
+    # j=i+1. (2D array is overkill but helps avoid confusion.)
+    t_list = np.zeros((num_wl, num_layers), dtype=complex)
+    r_list = np.zeros((num_wl, num_layers), dtype=complex)
+
+    construct_r_t_list(n_list, cos_th_list, pol, r_list, t_list)
+
+    # At the interface between the (n-1)st and nth material, let v_n be the
+    # amplitude of the wave on the nth side heading forwards (away from the
+    # boundary), and let w_n be the amplitude on the nth side heading backwards
+    # (towards the boundary). Then (v_n,w_n) = M_n (v_{n+1},w_{n+1}). M_n is
+    # M_list[n]. M_0 and M_{num_layers-1} are not defined.
+    # My M is a bit different than Sernelius's, but Mtilde is the same.
+
+    M_list = np.zeros((num_layers, num_wl, 2, 2), dtype=complex)
+    construct_M_list(num_layers, delta, r_list, t_list, M_list)
+
+    Mtilde = make_2x2_array(np.ones_like(delta[0]), np.zeros_like(delta[0]), np.zeros_like(delta[0]),
+                            np.ones_like(delta[0]), dtype=complex)
+    construct_Mtilde(num_layers, M_list, Mtilde)
+
+    r, t, R, T = construct_r_t_R_T(Mtilde, pol, n_list[0], n_list[-1], cos_th_0, cos_th_list[-1])
+
+    # vw_list[n] = [v_n, w_n]. v_0 and w_0 are undefined because the 0th medium
+    # has no left interface.
+    vw_list = []
+    power_entering = []
+    if detailed:
+        vw_list = np.zeros((num_layers, num_wl, 2), dtype=complex)
+        vw = np.zeros((num_wl, 2, 2), dtype=complex)
+        vw[:, 0, 0] = t
+        vw[:, 0, 1] = t
+        vw_list[-1] = vw[:, 0, :]
+        construct_vw(num_layers, M_list, vw, vw_list)
+
+        power_entering = power_entering_from_r(
+            pol, r, n_list[0], cos_th_0)
+
+    return {'r': r, 't': t, 'R': R, 'T': T, 'power_entering': power_entering,
+            'vw_list': vw_list, 'kz_list': kz_list, 'th_list': th_list,
+            'pol': pol, 'n_list': n_list, 'd_list': d_list, 'th_0': th_0,
+            'lam_vac': lam_vac}

--- a/solcore/absorption_calculator/tmm_core_cpu_parallel.py
+++ b/solcore/absorption_calculator/tmm_core_cpu_parallel.py
@@ -176,14 +176,12 @@ def coh_tmm(pol, n_list, d_list, th_0, lam_vac, detailed=True):
     d_list = d_list.astype(complex)
 
     # input tests
-    # if hasattr(th_0, 'size') and th_0.size > 1 and th_0.size != lam_vac.size:
-    #     raise ValueError('This function is not vectorized for angles; you need to run one angle calculation at a time.')
-    # if n_list.shape[0] != d_list.shape[0]:
-    #     raise ValueError("Problem with n_list or d_list!")
-    # if (d_list[0] != np.inf) or (d_list[-1] != np.inf):
-    #     raise ValueError('d_list must start and end with inf!')
-    # if any(abs((n_list[0] * np.sin(th_0)).imag) > 100 * EPSILON):
-    #     raise ValueError('Error in n0 or th0!')
+    if n_list.shape[0] != d_list.shape[0]:
+        raise ValueError("Problem with n_list or d_list!")
+    if (d_list[0] != np.inf) or (d_list[-1] != np.inf):
+        raise ValueError('d_list must start and end with inf!')
+    if any(abs((n_list[0] * np.sin(th_0)).imag) > 100 * EPSILON):
+        raise ValueError('Error in n0 or th0!')
     if hasattr(th_0, 'size'):
         th_0 = np.array(th_0)
     num_layers = n_list.shape[0]

--- a/solcore/absorption_calculator/tmm_core_gpu_parallel.py
+++ b/solcore/absorption_calculator/tmm_core_gpu_parallel.py
@@ -1,0 +1,400 @@
+"""
+This is implementation of the coh_tmm function using numba cuda (GPU parallelization)
+For large number of calculations (e.g. s and p polarization, 10,000 wavelengths x angles)
+the speed increase over tmm_core_vec implementation is significant, execution time @ 12% 
+(tested with NVIDIA GeForce RTX 4060)
+if further set detailed = False, will skip calculations of power_entering 
+and vw_list, and the function will be faster still, execution time roughly 40% x 12% = 4.8%
+Note however that the first time the function executes, the compilation will consume a lot of time,
+so the speed increase is only observed after an initial run
+"""
+
+import numpy as np
+import sys
+from numba import cuda
+import math
+import cmath
+
+EPSILON = sys.float_info.epsilon  # typical floating-point calculation error
+
+
+def list_snell(d_n_list, th_0, lam_vac, d_list, d_th_list, d_cos_th_list, d_delta, threadsperblock, catch_error):
+    d_kz_list = cuda.device_array((d_n_list.shape[0],d_n_list.shape[1]), dtype=complex)
+    succeed = False
+    if catch_error:
+        for _ in range(4):
+            try:
+                blockspergrid = math.ceil(d_n_list.shape[0]*d_n_list.shape[1] / threadsperblock)
+                list_snell_kernel_function[blockspergrid, threadsperblock](d_n_list, th_0, lam_vac, d_list, d_th_list, d_cos_th_list, d_kz_list, d_delta)
+                succeed = True
+            except cuda.cudadrv.driver.CudaAPIError as e:
+                threadsperblock //= 2
+    else:
+        blockspergrid = math.ceil(d_n_list.shape[0]*d_n_list.shape[1] / threadsperblock)
+        list_snell_kernel_function[blockspergrid, threadsperblock](d_n_list, th_0, lam_vac, d_list, d_th_list, d_cos_th_list, d_kz_list, d_delta)
+        succeed = True
+
+    th_list = d_th_list.copy_to_host()
+    kz_list = d_kz_list.copy_to_host()
+    return th_list, kz_list, threadsperblock, succeed
+
+@cuda.jit
+def list_snell_kernel_function(n_list, th_0, lam_vac, d_list, th_list, cos_th_list, kz_list, delta):
+    num_of_layers = n_list.shape[0]
+    num_of_rows = n_list.shape[1]
+    pos = cuda.grid(1)
+    if pos < num_of_layers*num_of_rows:
+        pos1 = int(pos/num_of_layers)
+        pos0 = pos - pos1*num_of_layers
+        th_list[pos0,pos1] = np.arcsin(n_list[0,pos1] * np.sin(th_0) / n_list[pos0,pos1])
+        cos_th_list[pos0,pos1] = np.cos(th_list[pos0,pos1])
+        kz_list[pos0,pos1] = 2 * np.pi * n_list[pos0,pos1] * cos_th_list[pos0,pos1] / lam_vac[pos1]
+        delta[pos0,pos1] = kz_list[pos0,pos1] * d_list[pos0,0]
+        if delta[pos0,pos1].imag > 100:
+            delta[pos0,pos1] = delta[pos0,pos1].real + 100j
+
+def interface_r(d_n_list, d_cos_th_list, d_r_list, threadsperblock, catch_error):
+    succeed = False
+    if catch_error:
+        for _ in range(4):
+            try:
+                blockspergrid = math.ceil((d_n_list.shape[0]-1)*d_n_list.shape[1]*2 / threadsperblock) 
+                interface_r_kernel_function[blockspergrid, threadsperblock](d_n_list, d_cos_th_list, d_r_list)
+                succeed = True
+            except cuda.cudadrv.driver.CudaAPIError as e:
+                threadsperblock //= 2
+    else:
+        blockspergrid = math.ceil((d_n_list.shape[0]-1)*d_n_list.shape[1]*2 / threadsperblock) 
+        interface_r_kernel_function[blockspergrid, threadsperblock](d_n_list, d_cos_th_list, d_r_list)
+        succeed = True
+    return threadsperblock, succeed
+
+@cuda.jit
+def interface_r_kernel_function(n_list, cos_th_list, r_list):
+    num_of_layers = n_list.shape[0]
+    num_of_rows = n_list.shape[1]
+    product = (num_of_layers-1)*num_of_rows
+    pos = cuda.grid(1)
+    if pos < product*2:
+        pol = int(pos/product)
+        remainder = pos - pol*product
+        pos1 = int(remainder/(num_of_layers-1))
+        pos0 = remainder - pos1*(num_of_layers-1)
+        if pol==0: #s
+            r_list[pos1,pos0,pol] = ((n_list[pos0,pos1] * cos_th_list[pos0,pos1] - n_list[pos0+1,pos1] * cos_th_list[pos0+1,pos1]) /
+                    (n_list[pos0,pos1] * cos_th_list[pos0,pos1] + n_list[pos0+1,pos1] * cos_th_list[pos0+1,pos1]))
+        else:
+            r_list[pos1,pos0,pol] = ((n_list[pos0+1,pos1] * cos_th_list[pos0,pos1] - n_list[pos0,pos1] * cos_th_list[pos0+1,pos1]) /
+                    (n_list[pos0+1,pos1] * cos_th_list[pos0,pos1] + n_list[pos0,pos1] * cos_th_list[pos0+1,pos1]))
+
+def interface_t(d_n_list, d_cos_th_list, d_t_list, threadsperblock, catch_error):
+    succeed = False
+    if catch_error:
+        for _ in range(4):
+            try:
+                blockspergrid = math.ceil((d_n_list.shape[0]-1)*d_n_list.shape[1]*2 / threadsperblock) 
+                interface_t_kernel_function[blockspergrid, threadsperblock](d_n_list, d_cos_th_list, d_t_list)
+                succeed = True
+            except cuda.cudadrv.driver.CudaAPIError as e:
+                threadsperblock //= 2
+    else:
+        blockspergrid = math.ceil((d_n_list.shape[0]-1)*d_n_list.shape[1]*2 / threadsperblock) 
+        interface_t_kernel_function[blockspergrid, threadsperblock](d_n_list, d_cos_th_list, d_t_list)
+        succeed = True
+    return threadsperblock, succeed
+
+@cuda.jit
+def interface_t_kernel_function(n_list, cos_th_list, t_list):
+    num_of_layers = n_list.shape[0]
+    num_of_rows = n_list.shape[1]
+    product = (num_of_layers-1)*num_of_rows
+    pos = cuda.grid(1)
+    if pos < product*2:
+        pol = int(pos/product)
+        remainder = pos - pol*product
+        pos1 = int(remainder/(num_of_layers-1))
+        pos0 = remainder - pos1*(num_of_layers-1)
+        if pol==0: #s
+            t_list[pos1,pos0,pol] = ((2 * n_list[pos0,pos1] * cos_th_list[pos0,pos1] ) /
+                    (n_list[pos0,pos1] * cos_th_list[pos0,pos1] + n_list[pos0+1,pos1] * cos_th_list[pos0+1,pos1]))
+        else:
+            t_list[pos1,pos0,pol] = ((2 * n_list[pos0,pos1] * cos_th_list[pos0,pos1] ) /
+                    (n_list[pos0+1,pos1] * cos_th_list[pos0,pos1] + n_list[pos0,pos1] * cos_th_list[pos0+1,pos1]))
+
+def make_M_list(d_delta, d_t_list, d_r_list, d_M_list, threadsperblock, catch_error):
+    succeed = False
+    if catch_error:
+        for _ in range(4):
+            try:
+                blockspergrid = math.ceil((d_M_list.shape[0]-1)*d_M_list.shape[1]*2 / threadsperblock) 
+                make_M_list_kernel_function[blockspergrid, threadsperblock](d_delta, d_t_list, d_r_list, d_M_list)
+                succeed = True
+            except cuda.cudadrv.driver.CudaAPIError as e:
+                threadsperblock //= 2
+    else:
+        blockspergrid = math.ceil((d_M_list.shape[0]-1)*d_M_list.shape[1]*2 / threadsperblock) 
+        make_M_list_kernel_function[blockspergrid, threadsperblock](d_delta, d_t_list, d_r_list, d_M_list)
+        succeed = True
+    return threadsperblock, succeed
+    
+@cuda.jit
+def make_M_list_kernel_function(delta, t_list, r_list, M_list):
+    num_of_layers = M_list.shape[0]
+    num_of_rows = M_list.shape[1]
+    product = (num_of_layers-1)*num_of_rows
+    pos = cuda.grid(1)
+    if pos < product*2:
+        pol = int(pos/product)
+        remainder = pos - pol*product
+        pos1 = int(remainder/(num_of_layers-1))
+        pos0 = remainder - pos1*(num_of_layers-1)
+        exp_ = 1.0
+        if pos0 > 0:
+            exp_ = cmath.exp(-1j * delta[pos0,pos1])
+        d = (1 / t_list[pos1,pos0,pol])
+        M_list[pos0,pos1,0,0,pol] = exp_*d
+        M_list[pos0,pos1,0,1,pol] = exp_*d*r_list[pos1,pos0,pol]
+        M_list[pos0,pos1,1,0,pol] = d/exp_*r_list[pos1,pos0,pol]
+        M_list[pos0,pos1,1,1,pol] = d/exp_
+
+def make_Mtilde(d_M_list, d_Mtilde, threadsperblock, catch_error):
+    succeed = False
+    if catch_error:
+        for _ in range(4):
+            try:
+                blockspergrid = math.ceil(d_Mtilde.shape[0]*2 / threadsperblock) 
+                make_Mtilde_kernel_function[blockspergrid, threadsperblock](d_M_list, d_Mtilde)
+                succeed = True
+            except cuda.cudadrv.driver.CudaAPIError as e:
+                threadsperblock //= 2
+    else:
+        blockspergrid = math.ceil(d_Mtilde.shape[0]*2 / threadsperblock) 
+        make_Mtilde_kernel_function[blockspergrid, threadsperblock](d_M_list, d_Mtilde)
+        succeed = True
+    return threadsperblock, succeed
+
+@cuda.jit
+def make_Mtilde_kernel_function(M_list, Mtilde):
+    num_of_rows = Mtilde.shape[0]
+    num_layers = M_list.shape[0]
+    pos = cuda.grid(1)
+    if pos < num_of_rows*2:
+        pol = int(pos/num_of_rows)
+        pos0 = pos - pol*num_of_rows
+        Mtilde[pos0,0,0,pol] = 1.0
+        Mtilde[pos0,0,1,pol] = 0.0
+        Mtilde[pos0,1,0,pol] = 0.0
+        Mtilde[pos0,1,1,pol] = 1.0
+        for i in range(0, num_layers - 1):
+            M00 = Mtilde[pos0,0,0,pol]*M_list[i,pos0,0,0,pol] + Mtilde[pos0,0,1,pol]*M_list[i,pos0,1,0,pol]
+            M01 = Mtilde[pos0,0,0,pol]*M_list[i,pos0,0,1,pol] + Mtilde[pos0,0,1,pol]*M_list[i,pos0,1,1,pol]
+            M10 = Mtilde[pos0,1,0,pol]*M_list[i,pos0,0,0,pol] + Mtilde[pos0,1,1,pol]*M_list[i,pos0,1,0,pol]
+            M11 = Mtilde[pos0,1,0,pol]*M_list[i,pos0,0,1,pol] + Mtilde[pos0,1,1,pol]*M_list[i,pos0,1,1,pol]
+            Mtilde[pos0,0,0,pol] = M00
+            Mtilde[pos0,0,1,pol] = M01
+            Mtilde[pos0,1,0,pol] = M10
+            Mtilde[pos0,1,1,pol] = M11
+
+def get_r_t_R_T(d_Mtilde, d_n_list, d_cos_th_list, threadsperblock, catch_error):
+    d_r = cuda.device_array((d_Mtilde.shape[0],2), dtype=complex) # last index is polarization
+    d_t = cuda.device_array((d_Mtilde.shape[0],2), dtype=complex)
+    d_R = cuda.device_array((d_Mtilde.shape[0],2), dtype=float)
+    d_T = cuda.device_array((d_Mtilde.shape[0],2), dtype=float)
+    succeed = False
+    if catch_error:
+        for _ in range(4):
+            try:
+                blockspergrid = math.ceil(d_Mtilde.shape[0]*2 / threadsperblock) 
+                get_r_t_R_T_kernel_function[blockspergrid, threadsperblock](d_Mtilde, d_n_list, d_cos_th_list, d_r, d_t, d_R, d_T)
+                succeed = True
+            except cuda.cudadrv.driver.CudaAPIError as e:
+                threadsperblock //= 2
+    else:
+        blockspergrid = math.ceil(d_Mtilde.shape[0]*2 / threadsperblock) 
+        get_r_t_R_T_kernel_function[blockspergrid, threadsperblock](d_Mtilde, d_n_list, d_cos_th_list, d_r, d_t, d_R, d_T)
+        succeed = True
+    
+    r = d_r.copy_to_host()
+    t = d_t.copy_to_host()
+    R = d_R.copy_to_host()
+    T = d_T.copy_to_host()
+    return r, t, R, T, threadsperblock, succeed
+
+@cuda.jit
+def get_r_t_R_T_kernel_function(Mtilde, n_list, cos_th_list, r, t, R, T):
+    num_of_rows = Mtilde.shape[0]
+    pos = cuda.grid(1)
+    if pos < num_of_rows*2:
+       pol = int(pos/num_of_rows)
+       pos0 = pos - pol*num_of_rows
+       r[pos0,pol] = Mtilde[pos0, 1, 0, pol] / Mtilde[pos0, 0, 0, pol]
+       t[pos0,pol] = 1.0 / Mtilde[pos0, 0, 0, pol]
+       R[pos0,pol] = abs(r[pos0,pol]) ** 2
+       if pol == 0: # s
+           T[pos0,pol] = abs(t[pos0,pol] ** 2) * (((n_list[-1][pos0] * cos_th_list[-1][pos0]).real) / (n_list[0][pos0] * cos_th_list[0][pos0]).real)
+       else:
+           T[pos0,pol] = abs(t[pos0,pol] ** 2) * (((n_list[-1][pos0] * cos_th_list[-1][pos0].conjugate()).real) /
+                              (n_list[0][pos0] * cos_th_list[0][pos0].conjugate()).real)
+       
+def build_vw(d_M_list,vw,vw_list, threadsperblock, catch_error):
+    d_vw = cuda.to_device(vw)
+    d_vw_list = cuda.to_device(vw_list)
+    succeed = False
+    if catch_error:
+        for _ in range(4):
+            try:
+                blockspergrid = math.ceil(d_M_list.shape[1]*2 / threadsperblock) 
+                build_vw_kernel_function[blockspergrid, threadsperblock](d_M_list,d_vw,d_vw_list)
+                succeed = True
+            except cuda.cudadrv.driver.CudaAPIError as e:
+                threadsperblock //= 2
+    else:
+        blockspergrid = math.ceil(d_M_list.shape[1]*2 / threadsperblock) 
+        build_vw_kernel_function[blockspergrid, threadsperblock](d_M_list,d_vw,d_vw_list)
+        succeed = True
+
+    revised_vw = d_vw.copy_to_host()
+    revised_vw_list = d_vw_list.copy_to_host()
+    return revised_vw, revised_vw_list, threadsperblock, succeed
+
+@cuda.jit
+def build_vw_kernel_function(M_list,vw,vw_list):
+    num_layers = M_list.shape[0]
+    num_of_rows = M_list.shape[1]
+    pos = cuda.grid(1)
+    if pos < num_of_rows*2:
+        pol = int(pos/num_of_rows)
+        pos0 = pos - pol*num_of_rows
+        for i in range(num_layers - 2, 0, -1):
+            M00 = M_list[i,pos0,0,0,pol]*vw[pos0,0,0,pol] + M_list[i,pos0,0,1,pol]*vw[pos0,1,0,pol]
+            M01 = M_list[i,pos0,0,0,pol]*vw[pos0,0,1,pol] + M_list[i,pos0,0,1,pol]*vw[pos0,1,1,pol]
+            M10 = M_list[i,pos0,1,0,pol]*vw[pos0,0,0,pol] + M_list[i,pos0,1,1,pol]*vw[pos0,1,0,pol]
+            M11 = M_list[i,pos0,1,0,pol]*vw[pos0,0,1,pol] + M_list[i,pos0,1,1,pol]*vw[pos0,1,1,pol]
+            vw[pos0,0,0,pol] = M00
+            vw[pos0,0,1,pol] = M01
+            vw[pos0,1,0,pol] = M10
+            vw[pos0,1,1,pol] = M11
+            vw_list[i,pos0,0,pol] = vw[pos0,0,1,pol]
+            vw_list[i,pos0,1,pol] = vw[pos0,1,1,pol]
+        vw_list[-1, pos0, 1,pol] = 0
+
+def power_entering_from_r(r, n_i, cos_th_i):
+    """
+    Calculate the power entering the first interface of the stack, starting with
+    reflection amplitude r. Normally this equals 1-R, but in the unusual case
+    that n_i is not real, it can be a bit different than 1-R. See manual.
+
+    n_i is refractive index of incident medium.
+
+    th_i is (complex) propegation angle through incident medium
+    (in radians, where 0=normal). "th" stands for "theta".
+    """
+    s_part = ((n_i * cos_th_i * (1 + np.conj(r[:,0])) * (1 - r[:,0])).real
+                / (n_i * cos_th_i).real)
+    p_part = ((n_i * np.conj(cos_th_i) * (1 + r[:,1]) * (1 - np.conj(r[:,1]))).real
+                / (n_i * np.conj(cos_th_i)).real)
+    return np.column_stack((s_part,p_part))
+
+class Coh_tmm_GPU:
+    def __init__(self):
+        self.GPU_enabled = False
+        if cuda.is_available():
+            device = cuda.get_current_device()
+            self.threadsperblock = [device.MAX_THREADS_PER_BLOCK]*7
+            self.GPU_enabled = True
+            self.catch_error = True
+
+    def coh_tmm(self, n_list, d_list, th_0, lam_vac, detailed=True):
+        # convert lists to numpy arrays if they're not already.
+        n_list = np.array(n_list)
+        d_list = np.array(d_list, dtype=float)[:, None]
+
+        # input tests
+        if hasattr(th_0, 'size') and th_0.size > 1 and th_0.size != lam_vac.size:
+            raise ValueError('This function is not vectorized for angles; you need to run one angle calculation at a time.')
+        if n_list.shape[0] != d_list.shape[0]:
+            raise ValueError("Problem with n_list or d_list!")
+        if (d_list[0] != np.inf) or (d_list[-1] != np.inf):
+            raise ValueError('d_list must start and end with inf!')
+        if any(abs((n_list[0] * np.sin(th_0)).imag) > 100 * EPSILON):
+            raise ValueError('Error in n0 or th0!')
+        if hasattr(th_0, 'size'):
+            th_0 = np.array(th_0)
+        num_layers = n_list.shape[0]
+        num_wl = n_list.shape[1]
+
+        # th_list is a list with, for each layer, the angle that the light travels
+        # through the layer. Computed with Snell's law. Note that the "angles" may be
+        # complex!
+        d_n_list = cuda.to_device(n_list)
+        d_th_list = cuda.device_array((n_list.shape[0],n_list.shape[1]), dtype=complex)
+        d_cos_th_list = cuda.device_array((n_list.shape[0],n_list.shape[1]), dtype=complex)
+        d_delta = cuda.device_array((n_list.shape[0],n_list.shape[1]), dtype=complex)
+        d_list[0] = 0.0
+        d_list[-1] = 0.0
+        d_list = d_list.astype(complex)
+        th_list, kz_list, threadsperblock, success = list_snell(d_n_list, th_0, lam_vac, d_list, d_th_list, d_cos_th_list, d_delta, self.threadsperblock[0], self.catch_error)
+        self.threadsperblock[0] = threadsperblock
+
+        olderr = np.seterr(invalid='ignore')
+        np.seterr(**olderr)
+
+        d_t_list = cuda.device_array((num_wl, num_layers, 2), dtype=complex) # last index is for both s and p
+        d_r_list = cuda.device_array((num_wl, num_layers, 2), dtype=complex) # last index is for both s and p
+        threadsperblock, success = interface_r(d_n_list, d_cos_th_list, d_r_list, self.threadsperblock[1], self.catch_error)
+        if not success:
+            return {}, False
+        self.threadsperblock[1] = threadsperblock
+        threadsperblock, success = interface_t(d_n_list, d_cos_th_list, d_t_list, self.threadsperblock[2], self.catch_error)
+        if not success:
+            return {}, False
+        self.threadsperblock[2] = threadsperblock
+
+        d_M_list = cuda.device_array((n_list.shape[0],n_list.shape[1],2,2,2), dtype=complex) # the last index is for both polarities
+        threadsperblock, success = make_M_list(d_delta, d_t_list, d_r_list, d_M_list, self.threadsperblock[3], self.catch_error)
+        if not success:
+            return {}, False
+        self.threadsperblock[3] = threadsperblock
+
+        d_Mtilde = cuda.device_array((n_list.shape[1],2,2,2), dtype=complex)
+        threadsperblock, success = make_Mtilde(d_M_list, d_Mtilde, self.threadsperblock[4], self.catch_error)
+        if not success:
+            return {}, False
+        self.threadsperblock[4] = threadsperblock
+
+        # Net complex transmission and reflection amplitudes
+        r, t, R, T, threadsperblock, success = get_r_t_R_T(d_Mtilde, d_n_list, d_cos_th_list, self.threadsperblock[5], self.catch_error)
+        if not success:
+            return {}, False
+        self.threadsperblock[5] = threadsperblock
+
+        # vw_list[n] = [v_n, w_n]. v_0 and w_0 are undefined because the 0th medium
+        # has no left interface.
+        vw_list = np.zeros((num_layers, num_wl, 2, 2), dtype=complex) # last index is polarization
+        power_entering = np.zeros((1,2))
+        if detailed:
+            vw = np.zeros((num_wl, 2, 2, 2), dtype=complex)
+            vw[:, 0, 0, 0] = t[:,0]
+            vw[:, 0, 1, 0] = t[:,0]
+            vw[:, 0, 0, 1] = t[:,1]
+            vw[:, 0, 1, 1] = t[:,1]
+            vw_list[-1] = vw[:, 0, :, :]
+            vw, vw_list, threadsperblock, success = build_vw(d_M_list,vw,vw_list, self.threadsperblock[6], self.catch_error)
+            if not success:
+                return {}, False
+            self.threadsperblock[6] = threadsperblock
+
+            # Net transmitted and reflected power, as a proportion of the incoming light
+            # power.
+            power_entering = power_entering_from_r(
+                r, n_list[0], np.cos(th_0))
+
+        # return both s [0] and p [1] results
+        return {'r': r[:,0], 't': t[:,0], 'R': R[:,0], 'T': T[:,0], 'power_entering': power_entering[:,0],
+                'vw_list': vw_list[:,:,:,0], 'kz_list': kz_list, 'th_list': th_list,
+                'pol': 's', 'n_list': n_list, 'd_list': d_list, 'th_0': th_0,
+                'lam_vac': lam_vac}, {'r': r[:,1], 't': t[:,1], 'R': R[:,1], 'T': T[:,1], 'power_entering': power_entering[:,1],
+                'vw_list': vw_list[:,:,:,1], 'kz_list': kz_list, 'th_list': th_list,
+                'pol': 'p', 'n_list': n_list, 'd_list': d_list, 'th_0': th_0,
+                'lam_vac': lam_vac}, True
+    

--- a/solcore/absorption_calculator/tmm_core_vec.py
+++ b/solcore/absorption_calculator/tmm_core_vec.py
@@ -282,8 +282,10 @@ def coh_tmm(pol, n_list, d_list, th_0, lam_vac, detailed=True, width_differentia
         for i, d in enumerate(width_differentials):
             if d is not None:
                 width_differentials_num += 1
+                kz_ = np.copy(kz_original)
                 ratio = 1.0 + d*1e9/d_list_truncated[i]
-                kz_list_truncated = np.hstack((kz_list_truncated,ratio*kz_original))
+                kz_[i,:] *= ratio
+                kz_list_truncated = np.hstack((kz_list_truncated,kz_))
     if n_list_diff is not None:
         for j, entry in enumerate(n_list_diff):
             if entry is not None:

--- a/solcore/absorption_calculator/tmm_core_vec.py
+++ b/solcore/absorption_calculator/tmm_core_vec.py
@@ -292,8 +292,8 @@ def coh_tmm(pol, n_list, d_list, th_0, lam_vac, detailed=True):
     # t_list[i,j] and r_list[i,j] are transmission and reflection amplitudes,
     # respectively, coming from i, going to j. Only need to calculate this when
     # j=i+1. (2D array is overkill but helps avoid confusion.)
-    t_list = np.zeros((num_wl, num_layers, num_layers), dtype=complex)
-    r_list = np.zeros((num_wl, num_layers, num_layers), dtype=complex)
+    t_list = np.zeros((num_wl, num_layers), dtype=complex)
+    r_list = np.zeros((num_wl, num_layers), dtype=complex)
 
     if pol == 's':
         t_list[:,:-1] = np.transpose((2 * n_list[:-1] * cos_th_list[:-1]) /

--- a/solcore/absorption_calculator/tmm_core_vec.py
+++ b/solcore/absorption_calculator/tmm_core_vec.py
@@ -251,8 +251,6 @@ def coh_tmm(pol, n_list, d_list, th_0, lam_vac, detailed=True):
     d_list = np.array(d_list, dtype=float)[:, None]
 
     # input tests
-    if hasattr(th_0, 'size') and th_0.size > 1 and th_0.size != lam_vac.size:
-        raise ValueError('This function is not vectorized for angles; you need to run one angle calculation at a time.')
     if n_list.shape[0] != d_list.shape[0]:
         raise ValueError("Problem with n_list or d_list!")
     if (d_list[0] != np.inf) or (d_list[-1] != np.inf):

--- a/solcore/absorption_calculator/transfer_matrix.py
+++ b/solcore/absorption_calculator/transfer_matrix.py
@@ -186,11 +186,8 @@ class OptiStack(object):
         out_diff = []
         if nk_differentials is not None:
             for i in range(self.num_layers):
-                print(i)
                 if len(nk_differentials)>i and nk_differentials[i] is not None:
                     nk_parameter_ = self.layers[i].material.nk_parameter
-                    print(nk_parameter_)
-                    print(nk_differentials[i])
                     self.layers[i].material.nk_parameter += nk_differentials[i]
                     out_diff.append(self.n_data[i](wl_m) + self.k_data[i](wl_m) * 1.0j)
                     self.layers[i].material.nk_parameter = nk_parameter_

--- a/solcore/absorption_calculator/transfer_matrix.py
+++ b/solcore/absorption_calculator/transfer_matrix.py
@@ -189,7 +189,9 @@ class OptiStack(object):
                 if len(nk_differentials)>i and nk_differentials[i] is not None:
                     nk_parameter_ = self.layers[i].material.nk_parameter
                     self.layers[i].material.nk_parameter += nk_differentials[i]
-                    out_diff.append(self.n_data[i](wl_m) + self.k_data[i](wl_m) * 1.0j)
+                    n_ = self.layers[i].material.n_interpolated(wl_m)
+                    k_ = self.layers[i].material.k_interpolated(wl_m)
+                    out_diff.append(n_ + k_ * 1.0j)
                     self.layers[i].material.nk_parameter = nk_parameter_
                 else:
                     out_diff.append(None)

--- a/solcore/absorption_calculator/transfer_matrix.py
+++ b/solcore/absorption_calculator/transfer_matrix.py
@@ -181,7 +181,7 @@ class OptiStack(object):
                 n0 = 1
 
         for i in range(self.num_layers):
-            if self.layers[i].nk_parameter is not None:
+            if hasattr(self.layers[i], 'nk_parameter') and self.layers[i].nk_parameter is not None:
                 self.layers[i].material.nk_parameter = self.layers[i].nk_parameter
                 n_ = self.layers[i].material.n_interpolated(wl_m)
                 k_ = self.layers[i].material.k_interpolated(wl_m)

--- a/solcore/absorption_calculator/transfer_matrix.py
+++ b/solcore/absorption_calculator/transfer_matrix.py
@@ -181,7 +181,13 @@ class OptiStack(object):
                 n0 = 1
 
         for i in range(self.num_layers):
-            out.append(self.n_data[i](wl_m) + self.k_data[i](wl_m) * 1.0j)
+            if self.layers[i].nk_parameter is not None:
+                self.layers[i].material.nk_parameter = self.layers[i].nk_parameter
+                n_ = self.layers[i].material.n_interpolated(wl_m)
+                k_ = self.layers[i].material.k_interpolated(wl_m)
+                out.append(n_ + k_ * 1.0j)
+            else:
+                out.append(self.n_data[i](wl_m) + self.k_data[i](wl_m) * 1.0j)
 
         out_diff = []
         if nk_differentials is not None:

--- a/solcore/material_system/material_system.py
+++ b/solcore/material_system/material_system.py
@@ -418,11 +418,12 @@ class BaseMaterial:
     def n_interpolated(self, x):
         assert len(self.composition) <= 1, "Can't interpolate 2d spectra yet"
 
-        try:
-            self.load_n_data()
-        except:
-            print('Material "{}" does not have n-data defined. Returning "ones"'.format(self.material_string))
-            return np.ones_like(x)
+        if self.n_data is None:
+            try:
+                self.load_n_data()
+            except:
+                print('Material "{}" does not have n-data defined. Returning "ones"'.format(self.material_string))
+                return np.ones_like(x)
 
         if len(self.composition) == 0:
             if self.nk_parameter is not None:
@@ -453,11 +454,12 @@ class BaseMaterial:
     def k_interpolated(self, x):
         assert len(self.composition) <= 1, "Can't interpolate 2d spectra yet"
 
-        try:
-            self.load_k_data()
-        except:
-            print('Material "{}" does not have k-data defined. Returning "zeros"'.format(self.material_string))
-            return np.zeros_like(x)
+        if self.k_data is None:
+            try:
+                self.load_k_data()
+            except:
+                print('Material "{}" does not have k-data defined. Returning "zeros"'.format(self.material_string))
+                return np.zeros_like(x)
 
         if len(self.composition) == 0:
             if self.nk_parameter is not None:

--- a/solcore/material_system/material_system.py
+++ b/solcore/material_system/material_system.py
@@ -418,7 +418,13 @@ class BaseMaterial:
     def n_interpolated(self, x):
         assert len(self.composition) <= 1, "Can't interpolate 2d spectra yet"
 
-        if self.n_data is None:
+        try:
+            if not hasattr(self,'n_data'):
+                self.n_data = None
+        except:
+            self.n_data = None
+
+        if not hasattr(self,'n_data') or self.n_data is None:
             try:
                 self.load_n_data()
             except:
@@ -454,7 +460,13 @@ class BaseMaterial:
     def k_interpolated(self, x):
         assert len(self.composition) <= 1, "Can't interpolate 2d spectra yet"
 
-        if self.k_data is None:
+        try:
+            if not hasattr(self,'k_data'):
+                self.k_data = None
+        except:
+            self.k_data = None
+
+        if not hasattr(self,'k_data') or self.k_data is None:
             try:
                 self.load_k_data()
             except:

--- a/solcore/structure.py
+++ b/solcore/structure.py
@@ -66,7 +66,7 @@ class Layer:
     """ Class that stores the information about layers of materials, such as thickness and composition.
     It is the building block of the 'Structures' """
 
-    def __init__(self, width, material, role=None, geometry=None, **kwargs):
+    def __init__(self, width, material, nk_parameter=None, role=None, geometry=None, **kwargs):
         """ Layer class constructor.
 
         :param width: Width of the layer, in SI units.
@@ -75,6 +75,7 @@ class Layer:
         :param kwargs: Any other keyword parameter which will become part of the layer attributes
         """
         self.width = width
+        self.nk_parameter = nk_parameter
         self.material = material
         self.role = role
         self.geometry = geometry


### PR DESCRIPTION
s and p polarization, 10000 wavelength x angles, 6 layers, calculate coh_tmm:
before speed increase: 4.178s
after speed increase: 2.399s
after speed increase, non-detailed mode: 1.948s
CPU parallelization with 24 cores
CPU parallelization: 0.844s
CPU parallelization, non-detailed mode: 0.719s
GPU parallelization with NVIDIA GeForce RTX 4060
GPU parallelization: 0.296s
GPU parallelization, non-detailed mode: 0.118s