### PR TITLE
Add generation rate to Sesame PDD output

### DIFF
--- a/.github/workflows/test_unit_and_examples.yml
+++ b/.github/workflows/test_unit_and_examples.yml
@@ -151,7 +151,8 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
            brew reinstall gfortran openblas
-           brew install ngspice boost suite-sparse
+           brew install ngspice boost@1.85 suite-sparse
+           brew link boost@1.85
 
       - name: Install Python dependecies
         run: |

--- a/.github/workflows/test_unit_and_examples.yml
+++ b/.github/workflows/test_unit_and_examples.yml
@@ -78,7 +78,6 @@ jobs:
           uv pip install --system wheel setuptools
           git clone https://github.com/phoebe-p/S4
           cd S4
-          git checkout rename_interpolator
           make S4_pyext --file="Makefile.m1"
           cd ..
           rm -rf S4
@@ -151,7 +150,8 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
            brew reinstall gfortran openblas
-           brew install ngspice boost suite-sparse
+           brew install ngspice boost@1.85 suite-sparse
+           brew link boost@1.85
 
       - name: Install Python dependecies
         run: |

--- a/.github/workflows/test_unit_and_examples.yml
+++ b/.github/workflows/test_unit_and_examples.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Install S4 (macOS - arm)
         if: matrix.os == 'macos-latest'
         run: |
+          brew config
           uv pip install --system wheel setuptools
           git clone https://github.com/phoebe-p/S4
           cd S4

--- a/.github/workflows/test_unit_and_examples.yml
+++ b/.github/workflows/test_unit_and_examples.yml
@@ -50,7 +50,8 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
            brew reinstall gfortran openblas
-           brew install ngspice boost suite-sparse
+           brew install ngspice boost@1.85 suite-sparse
+           brew link boost@1.85
 
       - name: Install system dependencies in MacOS (Intel)
         if: matrix.os == 'macos-13'
@@ -74,7 +75,6 @@ jobs:
       - name: Install S4 (macOS - arm)
         if: matrix.os == 'macos-latest'
         run: |
-          brew config
           uv pip install --system wheel setuptools
           git clone https://github.com/phoebe-p/S4
           cd S4
@@ -151,8 +151,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
            brew reinstall gfortran openblas
-           brew install ngspice boost@1.85 suite-sparse
-           brew link boost@1.85
+           brew install ngspice boost suite-sparse
 
       - name: Install Python dependecies
         run: |

--- a/docs/source/Solvers/SesameDDsolver.rst
+++ b/docs/source/Solvers/SesameDDsolver.rst
@@ -79,7 +79,8 @@ IV for with an attribute called ``pdd_output``, which contains the following:
 - ``pdd_output.Raug``: the Auger recombination rate (m\ :sup:`-3` s\ :sup:`-1`)
 - ``pdd_output.Rsrh``: the bulk recombination due to Shockley-Read-Hall processes (m\ :sup:`-3` s\ :sup:`-1`)
 
-Each of these is a 2-dimensional array, with dimensions ``(len(options.internal_voltages), len(mesh))``.
+Each of these is a 2-dimensional array, with dimensions ``(len(options.internal_voltages), len(mesh))``,
+with the exception of ``G`` which is 1D (only position-dependent, not a function of the voltage).
 
 Sub-function documentation
 ---------------------------

--- a/docs/source/Solvers/SesameDDsolver.rst
+++ b/docs/source/Solvers/SesameDDsolver.rst
@@ -74,6 +74,7 @@ IV for with an attribute called ``pdd_output``, which contains the following:
 - ``pdd_output.Ev``: the level of the valence band (eV)
 - ``pdd_output.Efe``: the electron quasi-Fermi level (eV)
 - ``pdd_output.Efh``: the hole quasi-Fermi level (eV)
+- ``pdd_output.G``: the generation rate as a function of position at the locations in the mesh (``junction.mesh``) (m\ :sup:`-3` s\ :sup:`-1`)
 - ``pdd_output.Rrad``: the radiative recombination rate (m\ :sup:`-3` s\ :sup:`-1`)
 - ``pdd_output.Raug``: the Auger recombination rate (m\ :sup:`-3` s\ :sup:`-1`)
 - ``pdd_output.Rsrh``: the bulk recombination due to Shockley-Read-Hall processes (m\ :sup:`-3` s\ :sup:`-1`)

--- a/examples/GaAs_cell_drift_diffusion_np.py
+++ b/examples/GaAs_cell_drift_diffusion_np.py
@@ -80,8 +80,8 @@ solar_cell_optics = SolarCell(
     ARC_layers + junction_layers + [Layer(si('100um'), GaAs_substrate)], substrate=Ag,
 )
 
-solar_cell_solver(solar_cell, 'iv', options)
-solar_cell_solver(solar_cell, 'qe', options)
+# solar_cell_solver(solar_cell, 'iv', options)
+# solar_cell_solver(solar_cell, 'qe', options)
 
 solar_cell_solver(solar_cell_sesame, 'iv', options)
 solar_cell_solver(solar_cell_sesame, 'qe', options)
@@ -89,29 +89,29 @@ solar_cell_solver(solar_cell_sesame, 'qe', options)
 solar_cell_solver(solar_cell_optics, 'optics', options)
 
 absorption_per_layer = np.array([layer.layer_absorption for layer in solar_cell_optics])
-
-fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
-
-ax1.plot(solar_cell.iv['IV'][0], solar_cell.iv['IV'][1]/10, '--k', label='Overall IV')
-ax1.plot(options.voltages, -solar_cell[2].iv(options.voltages)/10, '-r', label='junction IV')
-
-ax1.legend()
-ax1.set_title("Fortran PDD solver")
-
-ax2.stackplot(options.wavelength*1e9, 100*absorption_per_layer[::-1], alpha=0.4)
-ax2.plot(options.wavelength*1e9, 100*solar_cell[2].eqe(options.wavelength), '-k')
-
-ax2.legend(['substrate', 'GaAs BSF', 'GaAs base', 'GaAs emitter', 'AlGaAs window', 'ZnS', 'MgF$_2$'])
-
-ax1.set_xlabel('Voltage (V)')
-ax1.set_ylabel('Current density (mA/cm$^2$)')
-ax1.set_ylim(-35, 10)
-
-ax2.set_xlabel('Wavelength (nm)')
-ax2.set_ylabel('EQE / Absorption (%)')
-
-plt.tight_layout()
-plt.show()
+#
+# fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
+#
+# ax1.plot(solar_cell.iv['IV'][0], solar_cell.iv['IV'][1]/10, '--k', label='Overall IV')
+# ax1.plot(options.voltages, -solar_cell[2].iv(options.voltages)/10, '-r', label='junction IV')
+#
+# ax1.legend()
+# ax1.set_title("Fortran PDD solver")
+#
+# ax2.stackplot(options.wavelength*1e9, 100*absorption_per_layer[::-1], alpha=0.4)
+# ax2.plot(options.wavelength*1e9, 100*solar_cell[2].eqe(options.wavelength), '-k')
+#
+# ax2.legend(['substrate', 'GaAs BSF', 'GaAs base', 'GaAs emitter', 'AlGaAs window', 'ZnS', 'MgF$_2$'])
+#
+# ax1.set_xlabel('Voltage (V)')
+# ax1.set_ylabel('Current density (mA/cm$^2$)')
+# ax1.set_ylim(-35, 10)
+#
+# ax2.set_xlabel('Wavelength (nm)')
+# ax2.set_ylabel('EQE / Absorption (%)')
+#
+# plt.tight_layout()
+# plt.show()
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
 
@@ -134,4 +134,18 @@ ax2.set_xlabel('Wavelength (nm)')
 ax2.set_ylabel('EQE / Absorption (%)')
 
 plt.tight_layout()
+plt.show()
+
+z_pos = np.linspace(0, 3230, 4000)*1e-9
+
+gen_per_wl = solar_cell_sesame[2].absorbed(z_pos)
+
+
+
+gen_total = np.trapz(gen_per_wl * options.light_source.spectrum(options.wavelength, output_units="photon_flux_per_m")[1][None, :], options.wavelength)
+
+plt.figure()
+plt.plot(solar_cell_sesame[2].mesh*1e6, solar_cell_sesame[2].pdd_output.generation, '-k', label='Generation')
+plt.plot(z_pos*1e6, gen_total, '--r')
+
 plt.show()

--- a/examples/GaAs_cell_drift_diffusion_np.py
+++ b/examples/GaAs_cell_drift_diffusion_np.py
@@ -80,8 +80,8 @@ solar_cell_optics = SolarCell(
     ARC_layers + junction_layers + [Layer(si('100um'), GaAs_substrate)], substrate=Ag,
 )
 
-# solar_cell_solver(solar_cell, 'iv', options)
-# solar_cell_solver(solar_cell, 'qe', options)
+solar_cell_solver(solar_cell, 'iv', options)
+solar_cell_solver(solar_cell, 'qe', options)
 
 solar_cell_solver(solar_cell_sesame, 'iv', options)
 solar_cell_solver(solar_cell_sesame, 'qe', options)
@@ -89,29 +89,29 @@ solar_cell_solver(solar_cell_sesame, 'qe', options)
 solar_cell_solver(solar_cell_optics, 'optics', options)
 
 absorption_per_layer = np.array([layer.layer_absorption for layer in solar_cell_optics])
-#
-# fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
-#
-# ax1.plot(solar_cell.iv['IV'][0], solar_cell.iv['IV'][1]/10, '--k', label='Overall IV')
-# ax1.plot(options.voltages, -solar_cell[2].iv(options.voltages)/10, '-r', label='junction IV')
-#
-# ax1.legend()
-# ax1.set_title("Fortran PDD solver")
-#
-# ax2.stackplot(options.wavelength*1e9, 100*absorption_per_layer[::-1], alpha=0.4)
-# ax2.plot(options.wavelength*1e9, 100*solar_cell[2].eqe(options.wavelength), '-k')
-#
-# ax2.legend(['substrate', 'GaAs BSF', 'GaAs base', 'GaAs emitter', 'AlGaAs window', 'ZnS', 'MgF$_2$'])
-#
-# ax1.set_xlabel('Voltage (V)')
-# ax1.set_ylabel('Current density (mA/cm$^2$)')
-# ax1.set_ylim(-35, 10)
-#
-# ax2.set_xlabel('Wavelength (nm)')
-# ax2.set_ylabel('EQE / Absorption (%)')
-#
-# plt.tight_layout()
-# plt.show()
+
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
+
+ax1.plot(solar_cell.iv['IV'][0], solar_cell.iv['IV'][1]/10, '--k', label='Overall IV')
+ax1.plot(options.voltages, -solar_cell[2].iv(options.voltages)/10, '-r', label='junction IV')
+
+ax1.legend()
+ax1.set_title("Fortran PDD solver")
+
+ax2.stackplot(options.wavelength*1e9, 100*absorption_per_layer[::-1], alpha=0.4)
+ax2.plot(options.wavelength*1e9, 100*solar_cell[2].eqe(options.wavelength), '-k')
+
+ax2.legend(['substrate', 'GaAs BSF', 'GaAs base', 'GaAs emitter', 'AlGaAs window', 'ZnS', 'MgF$_2$'])
+
+ax1.set_xlabel('Voltage (V)')
+ax1.set_ylabel('Current density (mA/cm$^2$)')
+ax1.set_ylim(-35, 10)
+
+ax2.set_xlabel('Wavelength (nm)')
+ax2.set_ylabel('EQE / Absorption (%)')
+
+plt.tight_layout()
+plt.show()
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
 
@@ -136,16 +136,19 @@ ax2.set_ylabel('EQE / Absorption (%)')
 plt.tight_layout()
 plt.show()
 
+
+# show that generation rate in optical solver, integrated with the spectrum, and used/saved by
+# Sesame are the same:
+
 z_pos = np.linspace(0, 3230, 4000)*1e-9
 
 gen_per_wl = solar_cell_sesame[2].absorbed(z_pos)
 
-
-
 gen_total = np.trapz(gen_per_wl * options.light_source.spectrum(options.wavelength, output_units="photon_flux_per_m")[1][None, :], options.wavelength)
 
 plt.figure()
-plt.plot(solar_cell_sesame[2].mesh*1e6, solar_cell_sesame[2].pdd_output.generation, '-k', label='Generation')
+plt.plot(solar_cell_sesame[2].mesh*1e6, solar_cell_sesame[2].pdd_output.G, '-k', label='Generation')
 plt.plot(z_pos*1e6, gen_total, '--r')
-
+plt.xlabel('Position (um)')
+plt.ylabel('Generation rate (m$^{-3}$s$^{-1}$)')
 plt.show()

--- a/examples/GaAs_cell_drift_diffusion_pn.py
+++ b/examples/GaAs_cell_drift_diffusion_pn.py
@@ -133,3 +133,19 @@ ax2.set_ylabel('EQE / Absorption (%)')
 
 plt.tight_layout()
 plt.show()
+
+# show that generation rate in optical solver, integrated with the spectrum, and used/saved by
+# Sesame are the same:
+
+z_pos = np.linspace(0, 3230, 4000)*1e-9
+
+gen_per_wl = solar_cell_sesame[2].absorbed(z_pos)
+
+gen_total = np.trapz(gen_per_wl * options.light_source.spectrum(options.wavelength, output_units="photon_flux_per_m")[1][None, :], options.wavelength)
+
+plt.figure()
+plt.plot(solar_cell_sesame[2].mesh*1e6, solar_cell_sesame[2].pdd_output.G, '-k', label='Generation')
+plt.plot(z_pos*1e6, gen_total, '--r')
+plt.xlabel('Position (um)')
+plt.ylabel('Generation rate (m$^{-3}$s$^{-1}$)')
+plt.show()

--- a/solcore/sesame_drift_diffusion/solve_pdd.py
+++ b/solcore/sesame_drift_diffusion/solve_pdd.py
@@ -369,13 +369,15 @@ def process_sesame_results(sys: Builder, result: dict):
 
     Each of these is a 2-dimensional array, with dimensions ``(len(options.internal_voltages), len(mesh))``.
 
-
         :param sys: a Sesame Builder object
         :param result: a dictionary containing the results from a Sesame calculation
     """
 
     line = ((0, 0), (np.max(sys.xpts), 0))
     n_voltages = len(result["v"])
+
+    generation = sys.g * sys.scaling.generation * 1e6 # multiply by internal sesame scaling factor,
+    # convert from cm-3 to m-3 (area and depth are in m, in sesame they are in cm)
 
     potential = result["v"] * sys.scaling.energy
     Efe = result["efn"] * sys.scaling.energy
@@ -411,6 +413,7 @@ def process_sesame_results(sys: Builder, result: dict):
         )  # m-3
 
     output = State(
+        generation=generation,
         potential=potential,
         Efe=Efe,
         Efh=Efh,

--- a/solcore/sesame_drift_diffusion/solve_pdd.py
+++ b/solcore/sesame_drift_diffusion/solve_pdd.py
@@ -210,7 +210,7 @@ def iv_sesame(junction, options):
         last_non_nan = shunted_current[non_nans[-1]]
 
     else:
-        Exception(
+        raise Exception(
             "No solutions found for IV curve. Try increasing the number of voltage points scanned."
         )
 

--- a/solcore/sesame_drift_diffusion/solve_pdd.py
+++ b/solcore/sesame_drift_diffusion/solve_pdd.py
@@ -413,7 +413,7 @@ def process_sesame_results(sys: Builder, result: dict):
         )  # m-3
 
     output = State(
-        generation=generation,
+        G=generation,
         potential=potential,
         Efe=Efe,
         Efh=Efh,

--- a/tests/test_sesame_pdd.py
+++ b/tests/test_sesame_pdd.py
@@ -512,3 +512,47 @@ def test_reverse_bias():
     assert np.all(np_junction.iv(options.voltages) > 0)
 
 
+def test_generation_rate():
+
+    from solcore import material, si
+    from solcore.structure import Junction, Layer
+    from solcore.solar_cell_solver import solar_cell_solver, SolarCell
+    from solcore.sesame_drift_diffusion.process_structure import carrier_constants
+    from solcore.state import State
+    from solcore.light_source import LightSource
+
+    GaAs_p = material('GaAs')(T=300, Na=1e24,
+                              hole_minority_lifetime=1e-6, electron_minority_lifetime=1e-6)
+    GaAs_n = material('GaAs')(T=300, Nd=1e24,
+                              hole_minority_lifetime=1e-6, electron_minority_lifetime=1e-6)
+
+    GaAs_p.electron_diffusion_length = carrier_constants("electron_diffusion_length", GaAs_p)
+    GaAs_n.hole_diffusion_length = carrier_constants("hole_diffusion_length", GaAs_n)
+
+    options = State()
+    options.wavelength = np.linspace(300, 950, 100)*1e-9
+    options.voltages = np.linspace(-0.5, 1.3, 30)
+    options.internal_voltages = np.linspace(-0.5, 1.3, 30)
+    options.T = 300
+    options.light_iv = True
+    options.light_source = LightSource(source_type='standard', version='AM1.5g', x=options.wavelength, output_units='photon_flux_per_m')
+    options.da_mode = 'green'
+    options.optics_method = 'TMM'
+
+    mesh = np.linspace(0, 2200, 500)*1e-9
+
+    pn_junction = Junction([Layer(si('200nm'), GaAs_p, role='emitter'), Layer(si('2000nm'), GaAs_n, role='base')],
+                           kind='sesame_PDD', R_shunt=0.1, mesh=mesh)
+    solar_cell = SolarCell([pn_junction])
+    solar_cell_solver(solar_cell, 'iv', options)
+
+    z_pos = np.linspace(0, 2200, 500) * 1e-9
+
+    gen_per_wl = solar_cell(0).absorbed(z_pos)
+
+    gen_total = np.trapz(gen_per_wl * options.light_source.spectrum(options.wavelength,
+                                                                    output_units="photon_flux_per_m")[
+                                          1][None, :], options.wavelength)
+
+    gen_G = solar_cell(0).pdd_output.G
+    assert gen_total == approx(gen_G)

--- a/tests/test_sesame_pdd.py
+++ b/tests/test_sesame_pdd.py
@@ -1,6 +1,7 @@
 import numpy as np
 from pytest import approx, raises
 
+
 def test_constant_doping():
     # test sesame PDD process_structure when constant doping levels are passed
     from solcore import material, si


### PR DESCRIPTION
The generation rate G, calculated using the incident spectrum and whichever optical solver method is selected, is used by the PDD solver but there is currently no convenient way for the user to access it - they instead need to access the wavelength-dependent generation rate and integrate this manually with the incident spectrum. This adds the generation rate G in a junction to the outputs of the Sesame drift-diffusion solver easily accessible by the user after a calculation.

Also fix some unrelated issues relating to Boost library causing GitHub Actions tests for M1 Macs to fail.